### PR TITLE
Implement CLI methods for `connect` and `disconnect`

### DIFF
--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -1,6 +1,7 @@
 import api.EclairClientBuilder
-import commands.GetInfoCommand
 import commands.ConnectCommand
+import commands.GetInfoCommand
+import commands.DisconnectCommand
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ExperimentalCli
 
@@ -11,7 +12,8 @@ fun main(args: Array<String>) {
     val apiClientBuilder = EclairClientBuilder()
     parser.subcommands(
         GetInfoCommand(resultWriter, apiClientBuilder),
-        ConnectCommand(resultWriter, apiClientBuilder)
+        ConnectCommand(resultWriter, apiClientBuilder),
+        DisconnectCommand(resultWriter, apiClientBuilder)
     )
     parser.parse(args)
 }

--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -1,7 +1,7 @@
 import api.EclairClientBuilder
 import commands.ConnectCommand
-import commands.GetInfoCommand
 import commands.DisconnectCommand
+import commands.GetInfoCommand
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ExperimentalCli
 

--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -1,5 +1,6 @@
 import api.EclairClientBuilder
 import commands.GetInfoCommand
+import commands.ConnectCommand
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ExperimentalCli
 
@@ -9,7 +10,8 @@ fun main(args: Array<String>) {
     val resultWriter = ConsoleResultWriter()
     val apiClientBuilder = EclairClientBuilder()
     parser.subcommands(
-        GetInfoCommand(resultWriter, apiClientBuilder)
+        GetInfoCommand(resultWriter, apiClientBuilder),
+        ConnectCommand(resultWriter, apiClientBuilder)
     )
     parser.parse(args)
 }

--- a/src/nativeMain/kotlin/api/EclairClient.kt
+++ b/src/nativeMain/kotlin/api/EclairClient.kt
@@ -22,14 +22,14 @@ class EclairClientBuilder : IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = EclairClient(apiHost, apiPassword)
 }
 
+sealed class ConnectionTarget {
+    data class Uri(val uri: String) : ConnectionTarget()
+    data class NodeId(val nodeId: String) : ConnectionTarget()
+    data class Manual(val nodeId: String, val address: String, val port: Int? = null) : ConnectionTarget()
+}
+
 interface IEclairClient {
     suspend fun getInfo(): Either<ApiError, String>
-    sealed class ConnectionTarget {
-        data class Uri(val uri: String) : ConnectionTarget()
-        data class NodeId(val nodeId: String) : ConnectionTarget()
-        data class Manual(val nodeId: String, val address: String, val port: Int? = null) : ConnectionTarget()
-    }
-
     suspend fun connect(target: ConnectionTarget): Either<ApiError, String>
     suspend fun disconnect(nodeId: String): Either<ApiError, String>
 }
@@ -69,24 +69,24 @@ class EclairClient(private val apiHost: String, private val apiPassword: String)
         }
     }
 
-    override suspend fun connect(target: IEclairClient.ConnectionTarget): Either<ApiError, String> {
+    override suspend fun connect(target: ConnectionTarget): Either<ApiError, String> {
         return try {
             val response: HttpResponse = when (target) {
-                is IEclairClient.ConnectionTarget.Uri -> httpClient.submitForm(
+                is ConnectionTarget.Uri -> httpClient.submitForm(
                     url = "${apiHost}/connect",
                     formParameters = Parameters.build {
                         append("uri", target.uri)
                     }
                 )
 
-                is IEclairClient.ConnectionTarget.NodeId -> httpClient.submitForm(
+                is ConnectionTarget.NodeId -> httpClient.submitForm(
                     url = "${apiHost}/connect",
                     formParameters = Parameters.build {
                         append("nodeId", target.nodeId)
                     }
                 )
 
-                is IEclairClient.ConnectionTarget.Manual -> httpClient.submitForm(
+                is ConnectionTarget.Manual -> httpClient.submitForm(
                     url = "${apiHost}/connect",
                     formParameters = Parameters.build {
                         append("nodeId", target.nodeId)
@@ -99,7 +99,7 @@ class EclairClient(private val apiHost: String, private val apiPassword: String)
                 HttpStatusCode.OK -> Either.Right(Json.decodeFromString(response.bodyAsText()))
                 else -> Either.Left(convertHttpError(response.status))
             }
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             Either.Left(ApiError(0, e.message ?: "Unknown error"))
         }
     }
@@ -116,7 +116,7 @@ class EclairClient(private val apiHost: String, private val apiPassword: String)
                 HttpStatusCode.OK -> Either.Right(Json.decodeFromString(response.bodyAsText()))
                 else -> Either.Left(convertHttpError(response.status))
             }
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             Either.Left(ApiError(0, e.message ?: "Unknown error"))
         }
     }

--- a/src/nativeMain/kotlin/api/EclairClient.kt
+++ b/src/nativeMain/kotlin/api/EclairClient.kt
@@ -31,6 +31,7 @@ interface IEclairClient {
     }
 
     suspend fun connect(target: ConnectionTarget): Either<ApiError, String>
+    suspend fun disconnect(nodeId: String): Either<ApiError, String>
 }
 
 class EclairClient(private val apiHost: String, private val apiPassword: String) : IEclairClient {
@@ -103,4 +104,20 @@ class EclairClient(private val apiHost: String, private val apiPassword: String)
         }
     }
 
+    override suspend fun disconnect(nodeId: String): Either<ApiError, String> {
+        return try {
+            val response: HttpResponse = httpClient.submitForm(
+                url = "${apiHost}/disconnect",
+                formParameters = Parameters.build {
+                    append("nodeId", nodeId)
+                }
+            )
+            when (response.status) {
+                HttpStatusCode.OK -> Either.Right(Json.decodeFromString(response.bodyAsText()))
+                else -> Either.Left(convertHttpError(response.status))
+            }
+        } catch (e: Exception) {
+            Either.Left(ApiError(0, e.message ?: "Unknown error"))
+        }
+    }
 }

--- a/src/nativeMain/kotlin/commands/Base.kt
+++ b/src/nativeMain/kotlin/commands/Base.kt
@@ -1,0 +1,9 @@
+package commands
+
+import kotlinx.cli.*
+
+@OptIn(ExperimentalCli::class)
+abstract class BaseCommand(commandName: String, commandDescription: String): Subcommand(commandName, commandDescription) {
+    protected val password by option(ArgType.String, shortName = "p", description = "Password for the Eclair API (can be found in eclair.conf)").required()
+    protected val host by option(ArgType.String, description = "Host URL for the Eclair API (can be found in eclair.conf)").default("http://localhost:8080")
+}

--- a/src/nativeMain/kotlin/commands/Connect.kt
+++ b/src/nativeMain/kotlin/commands/Connect.kt
@@ -50,8 +50,7 @@ class ConnectCommand(
             else -> Either.Left(ApiError(400, "invalid request parameters"))
         }.map { response ->
             val result = when (response) {
-                "connected" -> ConnectionResult(true)
-                "already connected" -> ConnectionResult(true)
+                "connected", "already connected" -> ConnectionResult(true)
                 else -> ConnectionResult(false)
             }
             Serialization.encode(result)

--- a/src/nativeMain/kotlin/commands/Connect.kt
+++ b/src/nativeMain/kotlin/commands/Connect.kt
@@ -1,0 +1,52 @@
+package commands
+
+import IResultWriter
+import api.IEclairClient
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgType
+import kotlinx.coroutines.runBlocking
+
+class ConnectCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "connect",
+    "Connect to another lightning node. This will perform a connection but no channels will be opened. "
+) {
+    var uri by option(
+        ArgType.String,
+        description = "If the uri to the target node is not provided, eclair will use one of the addresses published by the remote peer in its node_announcement messages if it can be found."
+    )
+
+    var nodeId by option(
+        ArgType.String,
+        description = "Connect to another lightning node. This does not require a target address. Instead, eclair will use one of the addresses published by the remote peer in its node_announcement messages."
+    )
+
+    var address by option(
+        ArgType.String,
+        description = "The IPv4 host address of the node."
+    )
+    var port by option(
+        ArgType.Int,
+        description = "The port of the node(default: 9735)"
+    )
+
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val result = when {
+            uri != null -> eclairClient.connect(IEclairClient.ConnectionTarget.Uri(uri!!))
+            nodeId != null && address == null -> eclairClient.connect(IEclairClient.ConnectionTarget.NodeId(nodeId!!))
+            nodeId != null && address != null -> eclairClient.connect(
+                IEclairClient.ConnectionTarget.Manual(
+                    nodeId!!,
+                    address!!,
+                    port
+                )
+            )
+
+            else -> throw IllegalArgumentException("Either URI or nodeId must be provided.")
+        }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/commands/Connect.kt
+++ b/src/nativeMain/kotlin/commands/Connect.kt
@@ -1,10 +1,12 @@
 package commands
 
 import IResultWriter
-import api.IEclairClient
+import api.ConnectionTarget
 import api.IEclairClientBuilder
+import arrow.core.Either
 import kotlinx.cli.ArgType
 import kotlinx.coroutines.runBlocking
+import types.ApiError
 
 class ConnectCommand(
     private val resultWriter: IResultWriter,
@@ -13,39 +15,36 @@ class ConnectCommand(
     "connect",
     "Connect to another lightning node. This will perform a connection but no channels will be opened. "
 ) {
-    var uri by option(
+    private val uri by option(
         ArgType.String,
         description = "If the uri to the target node is not provided, eclair will use one of the addresses published by the remote peer in its node_announcement messages if it can be found."
     )
-
-    var nodeId by option(
+    private val nodeId by option(
         ArgType.String,
         description = "Connect to another lightning node. This does not require a target address. Instead, eclair will use one of the addresses published by the remote peer in its node_announcement messages."
     )
-
-    var address by option(
+    private val address by option(
         ArgType.String,
         description = "The IPv4 host address of the node."
     )
-    var port by option(
+    private val port by option(
         ArgType.Int,
-        description = "The port of the node(default: 9735)"
+        description = "The port of the node (default: 9735)"
     )
 
     override fun execute() = runBlocking {
         val eclairClient = eclairClientBuilder.build(host, password)
         val result = when {
-            uri != null -> eclairClient.connect(IEclairClient.ConnectionTarget.Uri(uri!!))
-            nodeId != null && address == null -> eclairClient.connect(IEclairClient.ConnectionTarget.NodeId(nodeId!!))
+            uri != null -> eclairClient.connect(ConnectionTarget.Uri(uri!!))
+            nodeId != null && address == null -> eclairClient.connect(ConnectionTarget.NodeId(nodeId!!))
             nodeId != null && address != null -> eclairClient.connect(
-                IEclairClient.ConnectionTarget.Manual(
+                ConnectionTarget.Manual(
                     nodeId!!,
                     address!!,
                     port
                 )
             )
-
-            else -> throw IllegalArgumentException("Either URI or nodeId must be provided.")
+            else -> Either.Left(ApiError(400, "invalid request parameters"))
         }
         resultWriter.write(result)
     }

--- a/src/nativeMain/kotlin/commands/Connect.kt
+++ b/src/nativeMain/kotlin/commands/Connect.kt
@@ -7,6 +7,8 @@ import arrow.core.Either
 import kotlinx.cli.ArgType
 import kotlinx.coroutines.runBlocking
 import types.ApiError
+import types.ConnectionResult
+import types.Serialization
 
 class ConnectCommand(
     private val resultWriter: IResultWriter,
@@ -44,7 +46,15 @@ class ConnectCommand(
                     port
                 )
             )
+
             else -> Either.Left(ApiError(400, "invalid request parameters"))
+        }.map { response ->
+            val result = when (response) {
+                "connected" -> ConnectionResult(true)
+                "already connected" -> ConnectionResult(true)
+                else -> ConnectionResult(false)
+            }
+            Serialization.encode(result)
         }
         resultWriter.write(result)
     }

--- a/src/nativeMain/kotlin/commands/Disconnect.kt
+++ b/src/nativeMain/kotlin/commands/Disconnect.kt
@@ -3,11 +3,8 @@ package commands
 import IResultWriter
 import api.IEclairClientBuilder
 import kotlinx.cli.ArgType
-import kotlinx.cli.ExperimentalCli
-import kotlinx.cli.required
 import kotlinx.coroutines.runBlocking
 
-@OptIn(ExperimentalCli::class)
 class DisconnectCommand(
     private val resultWriter: IResultWriter,
     private val eclairClientBuilder: IEclairClientBuilder
@@ -15,10 +12,10 @@ class DisconnectCommand(
     "disconnect",
     "Disconnect from a peer."
 ) {
-    private val nodeId by option(ArgType.String, description = "Disconnect from a connected peer.").required()
+    private val nodeId by option(ArgType.String, description = "Disconnect from a connected peer.")
     override fun execute() = runBlocking {
         val eclairClient = eclairClientBuilder.build(host, password)
-        val result = eclairClient.disconnect(nodeId)
+        val result = eclairClient.disconnect(nodeId!!)
         resultWriter.write(result)
     }
 }

--- a/src/nativeMain/kotlin/commands/Disconnect.kt
+++ b/src/nativeMain/kotlin/commands/Disconnect.kt
@@ -4,6 +4,8 @@ import IResultWriter
 import api.IEclairClientBuilder
 import kotlinx.cli.ArgType
 import kotlinx.coroutines.runBlocking
+import types.DisconnectionResult
+import types.Serialization
 
 class DisconnectCommand(
     private val resultWriter: IResultWriter,
@@ -15,7 +17,14 @@ class DisconnectCommand(
     private val nodeId by option(ArgType.String, description = "Disconnect from a connected peer.")
     override fun execute() = runBlocking {
         val eclairClient = eclairClientBuilder.build(host, password)
-        val result = eclairClient.disconnect(nodeId!!)
+        val result = eclairClient.disconnect(nodeId!!).map { response ->
+            val result = if (response.contains("disconnecting")) {
+                DisconnectionResult(true, response)
+            } else {
+                DisconnectionResult(false, response)
+            }
+            Serialization.encode(result)
+        }
         resultWriter.write(result)
     }
 }

--- a/src/nativeMain/kotlin/commands/Disconnect.kt
+++ b/src/nativeMain/kotlin/commands/Disconnect.kt
@@ -1,0 +1,24 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgType
+import kotlinx.cli.ExperimentalCli
+import kotlinx.cli.required
+import kotlinx.coroutines.runBlocking
+
+@OptIn(ExperimentalCli::class)
+class DisconnectCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "disconnect",
+    "Disconnect from a peer."
+) {
+    private val nodeId by option(ArgType.String, description = "Disconnect from a connected peer.").required()
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val result = eclairClient.disconnect(nodeId)
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/commands/GetInfo.kt
+++ b/src/nativeMain/kotlin/commands/GetInfo.kt
@@ -3,22 +3,17 @@ package commands
 import IResultWriter
 import api.IEclairClientBuilder
 import arrow.core.flatMap
-import kotlinx.cli.*
 import kotlinx.coroutines.runBlocking
 import types.NodeInfo
 import types.Serialization
 
-@OptIn(ExperimentalCli::class)
 class GetInfoCommand(
     private val resultWriter: IResultWriter,
     private val eclairClientBuilder: IEclairClientBuilder
-) : Subcommand(
+) : BaseCommand(
     "getinfo",
     "Returns information about this node instance such as version, features, nodeId and current block height."
 ) {
-    private var password by option(ArgType.String, shortName = "p", description = "Password for the Eclair API (can be found in eclair.conf)").required()
-    private var host by option(ArgType.String, description = "Host URL for the Eclair API (can be found in eclair.conf)").default("http://localhost:8080")
-
     override fun execute() = runBlocking {
         val eclairClient = eclairClientBuilder.build(host, password)
         val result = eclairClient.getInfo()

--- a/src/nativeMain/kotlin/types/EclairApiTypes.kt
+++ b/src/nativeMain/kotlin/types/EclairApiTypes.kt
@@ -23,3 +23,6 @@ data class NodeInfo(
     val publicAddresses: List<String>,
     val instanceId: String,
 ) : EclairApiType()
+
+@Serializable
+data class ConnectionResult(val success: Boolean) : EclairApiType()

--- a/src/nativeMain/kotlin/types/EclairApiTypes.kt
+++ b/src/nativeMain/kotlin/types/EclairApiTypes.kt
@@ -26,3 +26,6 @@ data class NodeInfo(
 
 @Serializable
 data class ConnectionResult(val success: Boolean) : EclairApiType()
+
+@Serializable
+data class DisconnectionResult(val success: Boolean, val message: String) : EclairApiType()

--- a/src/nativeTest/kotlin/commands/ConnectTest.kt
+++ b/src/nativeTest/kotlin/commands/ConnectTest.kt
@@ -1,58 +1,58 @@
 package commands
 
+import api.ConnectionTarget
 import api.IEclairClientBuilder
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ExperimentalCli
+import kotlinx.serialization.json.Json
 import mocks.DummyEclairClient
 import mocks.DummyResultWriter
 import mocks.FailingEclairClient
 import types.ApiError
+import types.ConnectionResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 @OptIn(ExperimentalCli::class)
 class ConnectCommandTest {
-    private fun runTest(eclairClient: IEclairClientBuilder, options: Array<String>): DummyResultWriter {
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
         val resultWriter = DummyResultWriter()
         val command = ConnectCommand(resultWriter, eclairClient)
         val parser = ArgParser("test")
         parser.subcommands(command)
-        parser.parse(options)
-        return resultWriter
-    }
-
-    @Test
-    fun `successful request via URI`() {
-        val resultWriter = runTest(
-            DummyEclairClient(),
+        parser.parse(
             arrayOf(
                 "connect",
-                "--host",
-                "http://localhost:8080",
                 "-p",
                 "password",
                 "--uri",
                 "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e@127.0.0.1:9736"
             )
         )
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request via URI`() {
+        val target =
+            ConnectionTarget.Uri("02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e@127.0.0.1:9736")
+        val resultWriter =
+            runTest(DummyEclairClient(connectResponseMap = mapOf(target to DummyEclairClient.validConnectResponse)))
         assertNull(resultWriter.lastError)
-        assertEquals(DummyEclairClient.validConnectResponse, resultWriter.lastResult)
+        assertNotNull(resultWriter.lastResult)
+        val format = Json { ignoreUnknownKeys = true }
+        assertEquals(
+            format.decodeFromString(ConnectionResult.serializer(), DummyEclairClient.validConnectResponse),
+            format.decodeFromString(ConnectionResult.serializer(), resultWriter.lastResult!!),
+        )
     }
 
     @Test
     fun `successful request via NodeId`() {
         val resultWriter = runTest(
             DummyEclairClient(),
-            arrayOf(
-                "connect",
-                "--host",
-                "http://localhost:8080",
-                "-p",
-                "password",
-                "--nodeId",
-                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e"
-            )
         )
         assertNull(resultWriter.lastError)
         assertEquals(DummyEclairClient.validConnectResponse, resultWriter.lastResult)
@@ -62,18 +62,8 @@ class ConnectCommandTest {
     fun `successful request via Manual`() {
         val resultWriter = runTest(
             DummyEclairClient(),
-            arrayOf(
-                "connect",
-                "--host",
-                "http://localhost:8080",
-                "-p",
-                "password",
-                "--nodeId",
-                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e",
-                "--address",
-                "127.0.0.1"
+
             )
-        )
         assertNull(resultWriter.lastError)
         assertEquals(DummyEclairClient.validConnectResponse, resultWriter.lastResult)
     }
@@ -83,16 +73,8 @@ class ConnectCommandTest {
         val error = ApiError(42, "test failure message")
         val resultWriter = runTest(
             FailingEclairClient(error),
-            arrayOf(
-                "connect",
-                "--host",
-                "http://localhost:8080",
-                "-p",
-                "password",
-                "--uri",
-                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e@127.0.0.1:9736"
+
             )
-        )
         assertNull(resultWriter.lastResult)
         assertEquals(error, resultWriter.lastError)
     }
@@ -102,16 +84,8 @@ class ConnectCommandTest {
         val error = ApiError(42, "test failure message")
         val resultWriter = runTest(
             FailingEclairClient(error),
-            arrayOf(
-                "connect",
-                "--host",
-                "http://localhost:8080",
-                "-p",
-                "password",
-                "--nodeId",
-                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e"
+
             )
-        )
         assertNull(resultWriter.lastResult)
         assertEquals(error, resultWriter.lastError)
     }
@@ -121,17 +95,6 @@ class ConnectCommandTest {
         val error = ApiError(42, "test failure message")
         val resultWriter = runTest(
             FailingEclairClient(error),
-            arrayOf(
-                "connect",
-                "--host",
-                "http://localhost:8080",
-                "-p",
-                "password",
-                "--nodeId",
-                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e",
-                "--address",
-                "127.0.0.1"
-            )
         )
         assertNull(resultWriter.lastResult)
         assertEquals(error, resultWriter.lastError)

--- a/src/nativeTest/kotlin/commands/ConnectTest.kt
+++ b/src/nativeTest/kotlin/commands/ConnectTest.kt
@@ -1,71 +1,85 @@
 package commands
 
-import api.ConnectionTarget
 import api.IEclairClientBuilder
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ExperimentalCli
-import kotlinx.serialization.json.Json
 import mocks.DummyEclairClient
 import mocks.DummyResultWriter
 import mocks.FailingEclairClient
 import types.ApiError
 import types.ConnectionResult
+import types.Serialization
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 @OptIn(ExperimentalCli::class)
 class ConnectCommandTest {
-    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+    private fun runTest(eclairClient: IEclairClientBuilder, options: Array<String>): DummyResultWriter {
         val resultWriter = DummyResultWriter()
         val command = ConnectCommand(resultWriter, eclairClient)
         val parser = ArgParser("test")
         parser.subcommands(command)
-        parser.parse(
+        parser.parse(options)
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request via URI`() {
+        val resultWriter = runTest(
+            DummyEclairClient(),
             arrayOf(
                 "connect",
+                "--host",
+                "http://localhost:8080",
                 "-p",
                 "password",
                 "--uri",
                 "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e@127.0.0.1:9736"
             )
         )
-        return resultWriter
-    }
-
-    @Test
-    fun `successful request via URI`() {
-        val target =
-            ConnectionTarget.Uri("02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e@127.0.0.1:9736")
-        val resultWriter =
-            runTest(DummyEclairClient(connectResponseMap = mapOf(target to DummyEclairClient.validConnectResponse)))
         assertNull(resultWriter.lastError)
-        assertNotNull(resultWriter.lastResult)
-        val format = Json { ignoreUnknownKeys = true }
-        assertEquals(
-            format.decodeFromString(ConnectionResult.serializer(), DummyEclairClient.validConnectResponse),
-            format.decodeFromString(ConnectionResult.serializer(), resultWriter.lastResult!!),
-        )
+        val expectedOutput = Serialization.encode(ConnectionResult(true))
+        assertEquals(expectedOutput, resultWriter.lastResult)
     }
 
     @Test
     fun `successful request via NodeId`() {
         val resultWriter = runTest(
             DummyEclairClient(),
+            arrayOf(
+                "connect",
+                "--host",
+                "http://localhost:8080",
+                "-p",
+                "password",
+                "--nodeId",
+                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e"
+            )
         )
         assertNull(resultWriter.lastError)
-        assertEquals(DummyEclairClient.validConnectResponse, resultWriter.lastResult)
+        val expectedOutput = Serialization.encode(ConnectionResult(true))
+        assertEquals(expectedOutput, resultWriter.lastResult)
     }
 
     @Test
     fun `successful request via Manual`() {
         val resultWriter = runTest(
             DummyEclairClient(),
+            arrayOf(
+                "connect",
+                "--host",
+                "http://localhost:8080",
+                "-p",
+                "password",
+                "--nodeId",
+                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e"
 
             )
+        )
         assertNull(resultWriter.lastError)
-        assertEquals(DummyEclairClient.validConnectResponse, resultWriter.lastResult)
+        val expectedOutput = Serialization.encode(ConnectionResult(true))
+        assertEquals(expectedOutput, resultWriter.lastResult)
     }
 
     @Test
@@ -73,8 +87,16 @@ class ConnectCommandTest {
         val error = ApiError(42, "test failure message")
         val resultWriter = runTest(
             FailingEclairClient(error),
-
+            arrayOf(
+                "connect",
+                "--host",
+                "http://localhost:8080",
+                "-p",
+                "password",
+                "--uri",
+                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e@127.0.0.1:9736"
             )
+        )
         assertNull(resultWriter.lastResult)
         assertEquals(error, resultWriter.lastError)
     }
@@ -84,8 +106,17 @@ class ConnectCommandTest {
         val error = ApiError(42, "test failure message")
         val resultWriter = runTest(
             FailingEclairClient(error),
-
+            arrayOf(
+                "connect",
+                "--host",
+                "http://localhost:8080",
+                "-p",
+                "password",
+                "--nodeId",
+                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e"
             )
+
+        )
         assertNull(resultWriter.lastResult)
         assertEquals(error, resultWriter.lastError)
     }
@@ -95,6 +126,17 @@ class ConnectCommandTest {
         val error = ApiError(42, "test failure message")
         val resultWriter = runTest(
             FailingEclairClient(error),
+            arrayOf(
+                "connect",
+                "--host",
+                "http://localhost:8080",
+                "-p",
+                "password",
+                "--nodeId",
+                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e",
+                "--address",
+                "127.0.0.1"
+            )
         )
         assertNull(resultWriter.lastResult)
         assertEquals(error, resultWriter.lastError)

--- a/src/nativeTest/kotlin/commands/ConnectTest.kt
+++ b/src/nativeTest/kotlin/commands/ConnectTest.kt
@@ -1,0 +1,139 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCli::class)
+class ConnectCommandTest {
+    private fun runTest(eclairClient: IEclairClientBuilder, options: Array<String>): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = ConnectCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(options)
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request via URI`() {
+        val resultWriter = runTest(
+            DummyEclairClient(),
+            arrayOf(
+                "connect",
+                "--host",
+                "http://localhost:8080",
+                "-p",
+                "password",
+                "--uri",
+                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e@127.0.0.1:9736"
+            )
+        )
+        assertNull(resultWriter.lastError)
+        assertEquals(DummyEclairClient.validConnectResponse, resultWriter.lastResult)
+    }
+
+    @Test
+    fun `successful request via NodeId`() {
+        val resultWriter = runTest(
+            DummyEclairClient(),
+            arrayOf(
+                "connect",
+                "--host",
+                "http://localhost:8080",
+                "-p",
+                "password",
+                "--nodeId",
+                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e"
+            )
+        )
+        assertNull(resultWriter.lastError)
+        assertEquals(DummyEclairClient.validConnectResponse, resultWriter.lastResult)
+    }
+
+    @Test
+    fun `successful request via Manual`() {
+        val resultWriter = runTest(
+            DummyEclairClient(),
+            arrayOf(
+                "connect",
+                "--host",
+                "http://localhost:8080",
+                "-p",
+                "password",
+                "--nodeId",
+                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e",
+                "--address",
+                "127.0.0.1"
+            )
+        )
+        assertNull(resultWriter.lastError)
+        assertEquals(DummyEclairClient.validConnectResponse, resultWriter.lastResult)
+    }
+
+    @Test
+    fun `api error via URI`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(
+            FailingEclairClient(error),
+            arrayOf(
+                "connect",
+                "--host",
+                "http://localhost:8080",
+                "-p",
+                "password",
+                "--uri",
+                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e@127.0.0.1:9736"
+            )
+        )
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+
+    @Test
+    fun `api error via NodeId`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(
+            FailingEclairClient(error),
+            arrayOf(
+                "connect",
+                "--host",
+                "http://localhost:8080",
+                "-p",
+                "password",
+                "--nodeId",
+                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e"
+            )
+        )
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+
+    @Test
+    fun `api error via Manual`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(
+            FailingEclairClient(error),
+            arrayOf(
+                "connect",
+                "--host",
+                "http://localhost:8080",
+                "-p",
+                "password",
+                "--nodeId",
+                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e",
+                "--address",
+                "127.0.0.1"
+            )
+        )
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+}

--- a/src/nativeTest/kotlin/commands/DisconnectTest.kt
+++ b/src/nativeTest/kotlin/commands/DisconnectTest.kt
@@ -1,0 +1,49 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCli::class)
+class DisconnectCommandTest {
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = DisconnectCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(
+            arrayOf(
+                "disconnect",
+                "-p",
+                "password",
+                "--nodeId",
+                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e"
+            )
+        )
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter = runTest(DummyEclairClient())
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        assertEquals(DummyEclairClient.validDisconnectResponse, resultWriter.lastResult!!)
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+}

--- a/src/nativeTest/kotlin/commands/DisconnectTest.kt
+++ b/src/nativeTest/kotlin/commands/DisconnectTest.kt
@@ -7,6 +7,8 @@ import mocks.DummyEclairClient
 import mocks.DummyResultWriter
 import mocks.FailingEclairClient
 import types.ApiError
+import types.DisconnectionResult
+import types.Serialization
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -36,7 +38,8 @@ class DisconnectCommandTest {
         val resultWriter = runTest(DummyEclairClient())
         assertNull(resultWriter.lastError)
         assertNotNull(resultWriter.lastResult)
-        assertEquals(DummyEclairClient.validDisconnectResponse, resultWriter.lastResult!!)
+        val expectedOutput = Serialization.encode(DisconnectionResult(true, DummyEclairClient.validDisconnectResponse))
+        assertEquals(expectedOutput, resultWriter.lastResult)
     }
 
     @Test

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -8,19 +8,24 @@ import types.ApiError
 
 class DummyEclairClient(
     private val getInfoResponse: String = validGetInfoResponse,
-    private val connectResponse: String = validConnectResponse,
+    private val connectResponseMap: Map<ConnectionTarget, String> = mapOf(),
     private val disconnectResponse: String = validDisconnectResponse
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
-    override suspend fun connect(target: ConnectionTarget): Either<ApiError, String> = Either.Right(connectResponse)
+    override suspend fun connect(target: ConnectionTarget): Either<ApiError, String> =
+        Either.Right(connectResponseMap[target] ?: validConnectResponse)
+
     override suspend fun disconnect(nodeId: String): Either<ApiError, String> = Either.Right(disconnectResponse)
 
     companion object {
         val validGetInfoResponse =
             """{"version":"0.9.0","nodeId":"03e319aa4ecc7a89fb8b3feb6efe9075864b91048bff5bef14efd55a69760ddf17","alias":"alice","color":"#49daaa","features":{"activated":{"var_onion_optin":"mandatory","option_static_remotekey":"optional"},"unknown":[151,178]},"chainHash":"06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f","network":"regtest","blockHeight":107,"publicAddresses":[],"instanceId":"be74bd9a-fc54-4f24-bc41-0477c9ce2fb4"}"""
         val invalidGetInfoResponse = """{"version":42}"""
-        val validConnectResponse = "connected"
+        val validConnectResponse = """{
+  "type": "types.ConnectionResult",
+  "success": true
+}"""
         val validDisconnectResponse =
             "peer 02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e disconnecting"
     }

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -8,13 +8,12 @@ import types.ApiError
 
 class DummyEclairClient(
     private val getInfoResponse: String = validGetInfoResponse,
-    private val connectResponseMap: Map<ConnectionTarget, String> = mapOf(),
+    private val connectResponseMap: String = validConnectResponse,
     private val disconnectResponse: String = validDisconnectResponse
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
-    override suspend fun connect(target: ConnectionTarget): Either<ApiError, String> =
-        Either.Right(connectResponseMap[target] ?: validConnectResponse)
+    override suspend fun connect(target: ConnectionTarget): Either<ApiError, String> = Either.Right(validConnectResponse)
 
     override suspend fun disconnect(nodeId: String): Either<ApiError, String> = Either.Right(disconnectResponse)
 
@@ -22,10 +21,7 @@ class DummyEclairClient(
         val validGetInfoResponse =
             """{"version":"0.9.0","nodeId":"03e319aa4ecc7a89fb8b3feb6efe9075864b91048bff5bef14efd55a69760ddf17","alias":"alice","color":"#49daaa","features":{"activated":{"var_onion_optin":"mandatory","option_static_remotekey":"optional"},"unknown":[151,178]},"chainHash":"06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f","network":"regtest","blockHeight":107,"publicAddresses":[],"instanceId":"be74bd9a-fc54-4f24-bc41-0477c9ce2fb4"}"""
         val invalidGetInfoResponse = """{"version":42}"""
-        val validConnectResponse = """{
-  "type": "types.ConnectionResult",
-  "success": true
-}"""
+        val validConnectResponse = "connected"
         val validDisconnectResponse =
             "peer 02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e disconnecting"
     }

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -1,5 +1,6 @@
 package mocks
 
+import api.ConnectionTarget
 import api.IEclairClient
 import api.IEclairClientBuilder
 import arrow.core.Either
@@ -12,14 +13,7 @@ class DummyEclairClient(
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
-    override suspend fun connect(target: IEclairClient.ConnectionTarget): Either<ApiError, String> {
-        return when (target) {
-            is IEclairClient.ConnectionTarget.Uri -> Either.Right(connectResponse)
-            is IEclairClient.ConnectionTarget.NodeId -> Either.Right(connectResponse)
-            is IEclairClient.ConnectionTarget.Manual -> Either.Right(connectResponse)
-        }
-    }
-
+    override suspend fun connect(target: ConnectionTarget): Either<ApiError, String> = Either.Right(connectResponse)
     override suspend fun disconnect(nodeId: String): Either<ApiError, String> = Either.Right(disconnectResponse)
 
     companion object {
@@ -35,6 +29,6 @@ class DummyEclairClient(
 class FailingEclairClient(private val error: ApiError) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
     override suspend fun getInfo(): Either<ApiError, String> = Either.Left(error)
-    override suspend fun connect(target: IEclairClient.ConnectionTarget): Either<ApiError, String> = Either.Left(error)
+    override suspend fun connect(target: ConnectionTarget): Either<ApiError, String> = Either.Left(error)
     override suspend fun disconnect(nodeId: String): Either<ApiError, String> = Either.Left(error)
 }

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -6,15 +6,24 @@ import arrow.core.Either
 import types.ApiError
 
 class DummyEclairClient(
-    private val getInfoResponse: String = validGetInfoResponse
+    private val getInfoResponse: String = validGetInfoResponse,
+    private val connectResponse: String = validConnectResponse,
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
 
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
+    override suspend fun connect(target: IEclairClient.ConnectionTarget): Either<ApiError, String> {
+        return when (target) {
+            is IEclairClient.ConnectionTarget.Uri -> Either.Right(connectResponse)
+            is IEclairClient.ConnectionTarget.NodeId -> Either.Right(connectResponse)
+            is IEclairClient.ConnectionTarget.Manual -> Either.Right(connectResponse)
+        }
+    }
 
     companion object {
         val validGetInfoResponse = """{"version":"0.9.0","nodeId":"03e319aa4ecc7a89fb8b3feb6efe9075864b91048bff5bef14efd55a69760ddf17","alias":"alice","color":"#49daaa","features":{"activated":{"var_onion_optin":"mandatory","option_static_remotekey":"optional"},"unknown":[151,178]},"chainHash":"06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f","network":"regtest","blockHeight":107,"publicAddresses":[],"instanceId":"be74bd9a-fc54-4f24-bc41-0477c9ce2fb4"}"""
         val invalidGetInfoResponse = """{"version":42}"""
+        val validConnectResponse = "connected"
     }
 }
 
@@ -22,4 +31,5 @@ class FailingEclairClient(private val error: ApiError) : IEclairClient, IEclairC
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
 
     override suspend fun getInfo(): Either<ApiError, String> = Either.Left(error)
+    override suspend fun connect(target: IEclairClient.ConnectionTarget): Either<ApiError, String> = Either.Left(error)
 }

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -8,9 +8,9 @@ import types.ApiError
 class DummyEclairClient(
     private val getInfoResponse: String = validGetInfoResponse,
     private val connectResponse: String = validConnectResponse,
+    private val disconnectResponse: String = validDisconnectResponse
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
-
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
     override suspend fun connect(target: IEclairClient.ConnectionTarget): Either<ApiError, String> {
         return when (target) {
@@ -20,16 +20,21 @@ class DummyEclairClient(
         }
     }
 
+    override suspend fun disconnect(nodeId: String): Either<ApiError, String> = Either.Right(disconnectResponse)
+
     companion object {
-        val validGetInfoResponse = """{"version":"0.9.0","nodeId":"03e319aa4ecc7a89fb8b3feb6efe9075864b91048bff5bef14efd55a69760ddf17","alias":"alice","color":"#49daaa","features":{"activated":{"var_onion_optin":"mandatory","option_static_remotekey":"optional"},"unknown":[151,178]},"chainHash":"06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f","network":"regtest","blockHeight":107,"publicAddresses":[],"instanceId":"be74bd9a-fc54-4f24-bc41-0477c9ce2fb4"}"""
+        val validGetInfoResponse =
+            """{"version":"0.9.0","nodeId":"03e319aa4ecc7a89fb8b3feb6efe9075864b91048bff5bef14efd55a69760ddf17","alias":"alice","color":"#49daaa","features":{"activated":{"var_onion_optin":"mandatory","option_static_remotekey":"optional"},"unknown":[151,178]},"chainHash":"06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f","network":"regtest","blockHeight":107,"publicAddresses":[],"instanceId":"be74bd9a-fc54-4f24-bc41-0477c9ce2fb4"}"""
         val invalidGetInfoResponse = """{"version":42}"""
         val validConnectResponse = "connected"
+        val validDisconnectResponse =
+            "peer 02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e disconnecting"
     }
 }
 
 class FailingEclairClient(private val error: ApiError) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
-
     override suspend fun getInfo(): Either<ApiError, String> = Either.Left(error)
     override suspend fun connect(target: IEclairClient.ConnectionTarget): Either<ApiError, String> = Either.Left(error)
+    override suspend fun disconnect(nodeId: String): Either<ApiError, String> = Either.Left(error)
 }


### PR DESCRIPTION
### This PR addresses issue #6 

- [x] Add the `connect` Command.
- [x] Add the `disconnect` Command.
- [x] Unit Tests for `connect`
- [x] Unit Tests for `disconnect`
- [ ] Work on [this comment](https://github.com/ACINQ/eclair-cli/pull/9#discussion_r1273186358)