### PR TITLE
Implement the `updaterelayfee` command

### DIFF
--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -16,7 +16,8 @@ fun main(args: Array<String>) {
         RbfOpenCommand(resultWriter, apiClientBuilder),
         CpfpBumpFeesCommand(resultWriter, apiClientBuilder),
         CloseCommand(resultWriter, apiClientBuilder),
-        ForceCloseCommand(resultWriter, apiClientBuilder)
+        ForceCloseCommand(resultWriter, apiClientBuilder),
+        UpdateRelayFeeCommand(resultWriter, apiClientBuilder)
     )
     parser.parse(args)
 }

--- a/src/nativeMain/kotlin/commands/UpdateRelayFee.kt
+++ b/src/nativeMain/kotlin/commands/UpdateRelayFee.kt
@@ -1,0 +1,61 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import arrow.core.Either
+import arrow.core.flatMap
+import kotlinx.cli.ArgType
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import types.ApiError
+
+class UpdateRelayFeeCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "updaterelayfee",
+    "Updates the fee policy for the specified nodeId."
+) {
+    private val nodeId by option(
+        ArgType.String,
+        description = "The nodeId of the peer you want to update"
+    )
+    private val nodeIds by option(
+        ArgType.String,
+        description = "The nodeIds of the peers you want to update"
+    )
+    private val feeBaseMsat by option(
+        ArgType.Int,
+        description = "The new base fee to use"
+    )
+    private val feeProportionalMillionths by option(
+        ArgType.Int,
+        description = "The new proportional fee to use"
+    )
+
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        val result = eclairClient.updaterelayfee(
+            nodeId,
+            nodeIds?.split(","),
+            feeBaseMsat!!,
+            feeProportionalMillionths!!
+        ).flatMap { apiResponse ->
+            try {
+                Either.Right(format.decodeFromString<Map<String, String>>(apiResponse))
+            } catch (e: Throwable) {
+                Either.Left(ApiError(1, "api response could not be parsed: $apiResponse"))
+            }
+        }
+            .map { decoded ->
+                format.encodeToString(decoded)
+            }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeTest/kotlin/commands/UpdateRelayFeeTest.kt
+++ b/src/nativeTest/kotlin/commands/UpdateRelayFeeTest.kt
@@ -1,0 +1,67 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import kotlinx.serialization.json.Json
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import kotlin.test.*
+
+class UpdateRelayFeeCommandTest {
+    @OptIn(ExperimentalCli::class)
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = UpdateRelayFeeCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(
+            arrayOf(
+                "updaterelayfee",
+                "-p",
+                "password",
+                "--nodeId",
+                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e",
+                "--feeBaseMsat",
+                "1000",
+                "--feeProportionalMillionths",
+                "1000"
+            )
+        )
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter = runTest(DummyEclairClient())
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        assertEquals(
+            format.parseToJsonElement(DummyEclairClient.validUpdateRelayFeeResponse),
+            format.parseToJsonElement(resultWriter.lastResult!!),
+        )
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(43, "updaterelayfee failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+
+    @Test
+    fun `serialization error`() {
+        val resultWriter = runTest(DummyEclairClient(updateRelayFeeResponse = "{invalidJson}"))
+        assertNull(resultWriter.lastResult)
+        assertNotNull(resultWriter.lastError)
+        assertTrue(resultWriter.lastError!!.message.contains("api response could not be parsed"))
+    }
+}

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -14,7 +14,8 @@ class DummyEclairClient(
     private val rbfOpenResponse: String = validRbfOpenResponse,
     private val cpfpbumpfeesResponse: String = validcpfpbumpfeesResponse,
     private val closeResponse: String = validCloseResponse,
-    private val forcecloseResponse: String = validForceCloseResponse
+    private val forcecloseResponse: String = validForceCloseResponse,
+    private val updateRelayFeeResponse: String = validUpdateRelayFeeResponse,
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
@@ -57,6 +58,13 @@ class DummyEclairClient(
         shortChannelIds: List<String>?,
     ): Either<ApiError, String> = Either.Right(forcecloseResponse)
 
+    override suspend fun updaterelayfee(
+        nodeId: String?,
+        nodeIds: List<String>?,
+        feeBaseMsat: Int,
+        feeProportionalMillionths: Int
+    ): Either<ApiError, String> = Either.Right(updateRelayFeeResponse)
+
     companion object {
         val validGetInfoResponse =
             """{"version":"0.9.0","nodeId":"03e319aa4ecc7a89fb8b3feb6efe9075864b91048bff5bef14efd55a69760ddf17","alias":"alice","color":"#49daaa","features":{"activated":{"var_onion_optin":"mandatory","option_static_remotekey":"optional"},"unknown":[151,178]},"chainHash":"06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f","network":"regtest","blockHeight":107,"publicAddresses":[],"instanceId":"be74bd9a-fc54-4f24-bc41-0477c9ce2fb4"}"""
@@ -76,6 +84,8 @@ class DummyEclairClient(
     "b7f194155be377e8c4b8fb3a8e8c465f6e7506b875e56c2a4bc8ef57df380641": "closed channel b7f194155be377e8c4b8fb3a8e8c465f6e7506b875e56c2a4bc8ef57df380641"
 }
 """
+        val validUpdateRelayFeeResponse =
+            """{"72ced03de5af1d82d17ea56b001b6ca70f84b81b89f34daed34975130685472c":"ok","9c894bf206ff533b4c335afdef207ede4618023a47c8e77721dcc731f5d56beb":"ok","34ff2892512058a6cd26749ed812da4aa8e16f5294527b05197b6ff181554be1":"ok","9ff6547359f841daf68730db7d4e41284fa6a38c80756f86e9cef2ce48340223":"ok","6af519c91261ddd2547c136d07e23a85db031cc8a04b92d14a9f55e2bf23a0f7":"ok","825366d6aea22b4f4abd55a997f9e333aff8dc69499c4cb8208d3e9bff93710f":"ok","c872066be83c163872864f9fcdd6ac2c8a2090fb1c65dd610495dddcf10279a1":"ok","b7f194155be377e8c4b8fb3a8e8c465f6e7506b875e56c2a4bc8ef57df380641":"ok","2f17330de81032c0efaf59f47ec7434267e8d02d638977c485d2148707ce8a56":"ok","62ba3cc9354cf0df5746972926434f4198f60de938a46bb345dd2c44157a2eb5":"ok","3cb0a0652a2005645f9aae3e333b975434e100d9a0663c418177f7c3c9c0bb41":"ok","cd990ca3f6a44f125165fa57011f45a4f37c8eacf7c44c724e0b1277eddb538f":"ok"}"""
     }
 }
 
@@ -119,5 +129,12 @@ class FailingEclairClient(private val error: ApiError) : IEclairClient, IEclairC
         shortChannelId: String?,
         channelIds: List<String>?,
         shortChannelIds: List<String>?,
+    ): Either<ApiError, String> = Either.Left(error)
+
+    override suspend fun updaterelayfee(
+        nodeId: String?,
+        nodeIds: List<String>?,
+        feeBaseMsat: Int,
+        feeProportionalMillionths: Int
     ): Either<ApiError, String> = Either.Left(error)
 }


### PR DESCRIPTION
This Pull Request adds the implementation of the `updaterelayfee` command. Besides unit tests, this is manually tested also.
This is the log:
```
claddy@claddy:~/Documents/eclair-cli$ eclair-cli.kexe updaterelayfee -p password --nodeIds 02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e,039743b8b5030cf15717f855e7a4e4d15b40c0c08ed2f219c739721570baae81d5 --feeBaseMsat 7856 --feeProportionalMillionths 5679
{
    "72ced03de5af1d82d17ea56b001b6ca70f84b81b89f34daed34975130685472c": "ok",
    "9c894bf206ff533b4c335afdef207ede4618023a47c8e77721dcc731f5d56beb": "ok",
    "34ff2892512058a6cd26749ed812da4aa8e16f5294527b05197b6ff181554be1": "ok",
    "9ff6547359f841daf68730db7d4e41284fa6a38c80756f86e9cef2ce48340223": "ok",
    "6af519c91261ddd2547c136d07e23a85db031cc8a04b92d14a9f55e2bf23a0f7": "ok",
    "825366d6aea22b4f4abd55a997f9e333aff8dc69499c4cb8208d3e9bff93710f": "ok",
    "c872066be83c163872864f9fcdd6ac2c8a2090fb1c65dd610495dddcf10279a1": "ok",
    "b7f194155be377e8c4b8fb3a8e8c465f6e7506b875e56c2a4bc8ef57df380641": "ok",
    "2f17330de81032c0efaf59f47ec7434267e8d02d638977c485d2148707ce8a56": "ok",
    "62ba3cc9354cf0df5746972926434f4198f60de938a46bb345dd2c44157a2eb5": "ok",
    "3cb0a0652a2005645f9aae3e333b975434e100d9a0663c418177f7c3c9c0bb41": "ok",
    "cd990ca3f6a44f125165fa57011f45a4f37c8eacf7c44c724e0b1277eddb538f": "ok"
}
```