### PR TITLE
Implement the `peers` command

### DIFF
--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -17,7 +17,8 @@ fun main(args: Array<String>) {
         CpfpBumpFeesCommand(resultWriter, apiClientBuilder),
         CloseCommand(resultWriter, apiClientBuilder),
         ForceCloseCommand(resultWriter, apiClientBuilder),
-        UpdateRelayFeeCommand(resultWriter, apiClientBuilder)
+        UpdateRelayFeeCommand(resultWriter, apiClientBuilder),
+        PeersCommand(resultWriter, apiClientBuilder)
     )
     parser.parse(args)
 }

--- a/src/nativeMain/kotlin/api/EclairClient.kt
+++ b/src/nativeMain/kotlin/api/EclairClient.kt
@@ -74,6 +74,8 @@ interface IEclairClient {
         feeBaseMsat: Int,
         feeProportionalMillionths: Int
     ): Either<ApiError, String>
+
+    suspend fun peers(): Either<ApiError, String>
 }
 
 class EclairClient(private val apiHost: String, private val apiPassword: String) : IEclairClient {
@@ -315,6 +317,18 @@ class EclairClient(private val apiHost: String, private val apiPassword: String)
             }
         } catch (e: Throwable) {
             Either.Left(ApiError(0, e.message ?: "Unknown exception"))
+        }
+    }
+
+    override suspend fun peers(): Either<ApiError, String> {
+        return try {
+            val response: HttpResponse = httpClient.post("$apiHost/peers")
+            when (response.status) {
+                HttpStatusCode.OK -> Either.Right(response.bodyAsText())
+                else -> Either.Left(convertHttpError(response.status))
+            }
+        } catch (e: Throwable) {
+            Either.Left(ApiError(0, e.message ?: "unknown exception"))
         }
     }
 }

--- a/src/nativeMain/kotlin/commands/Peers.kt
+++ b/src/nativeMain/kotlin/commands/Peers.kt
@@ -1,0 +1,40 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import arrow.core.Either
+import arrow.core.flatMap
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import types.ApiError
+import types.Peer
+
+class PeersCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "peers",
+    "Returns the list of currently known peers, both connected and disconnected."
+) {
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        val result = eclairClient.peers()
+            .flatMap { apiResponse ->
+                try {
+                    Either.Right(format.decodeFromString<List<Peer>>(apiResponse))
+                } catch (e: Throwable) {
+                    Either.Left(ApiError(1, "api response could not be parsed: $apiResponse"))
+                }
+            }
+            .map { decoded ->
+                format.encodeToString(decoded)
+            }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/types/EclairApiTypes.kt
+++ b/src/nativeMain/kotlin/types/EclairApiTypes.kt
@@ -29,3 +29,11 @@ data class ConnectionResult(val success: Boolean) : EclairApiType()
 
 @Serializable
 data class DisconnectionResult(val success: Boolean, val message: String) : EclairApiType()
+
+@Serializable
+data class Peer(
+    val nodeId: String,
+    val state: String,
+    val address: String? = null,
+    val channels: Int
+)

--- a/src/nativeTest/kotlin/commands/PeersTest.kt
+++ b/src/nativeTest/kotlin/commands/PeersTest.kt
@@ -1,0 +1,55 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import kotlinx.serialization.json.Json
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import kotlin.test.*
+
+class PeersCommandTest {
+    @OptIn(ExperimentalCli::class)
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = PeersCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(arrayOf("peers", "-p", "password"))
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter = runTest(DummyEclairClient(peersResponse = DummyEclairClient.validPeersResponse))
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        assertEquals(
+            format.parseToJsonElement(DummyEclairClient.validPeersResponse),
+            format.decodeFromString(resultWriter.lastResult!!),
+        )
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+
+    @Test
+    fun `serialization error`() {
+        val resultWriter = runTest(DummyEclairClient(peersResponse = "{invalidJson}"))
+        assertNull(resultWriter.lastResult)
+        assertNotNull(resultWriter.lastError)
+        assertTrue(resultWriter.lastError!!.message.contains("api response could not be parsed"))
+    }
+}

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -16,6 +16,7 @@ class DummyEclairClient(
     private val closeResponse: String = validCloseResponse,
     private val forcecloseResponse: String = validForceCloseResponse,
     private val updateRelayFeeResponse: String = validUpdateRelayFeeResponse,
+    private val peersResponse: String = validPeersResponse,
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
@@ -65,6 +66,8 @@ class DummyEclairClient(
         feeProportionalMillionths: Int
     ): Either<ApiError, String> = Either.Right(updateRelayFeeResponse)
 
+    override suspend fun peers(): Either<ApiError, String> = Either.Right(peersResponse)
+
     companion object {
         val validGetInfoResponse =
             """{"version":"0.9.0","nodeId":"03e319aa4ecc7a89fb8b3feb6efe9075864b91048bff5bef14efd55a69760ddf17","alias":"alice","color":"#49daaa","features":{"activated":{"var_onion_optin":"mandatory","option_static_remotekey":"optional"},"unknown":[151,178]},"chainHash":"06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f","network":"regtest","blockHeight":107,"publicAddresses":[],"instanceId":"be74bd9a-fc54-4f24-bc41-0477c9ce2fb4"}"""
@@ -86,6 +89,19 @@ class DummyEclairClient(
 """
         val validUpdateRelayFeeResponse =
             """{"72ced03de5af1d82d17ea56b001b6ca70f84b81b89f34daed34975130685472c":"ok","9c894bf206ff533b4c335afdef207ede4618023a47c8e77721dcc731f5d56beb":"ok","34ff2892512058a6cd26749ed812da4aa8e16f5294527b05197b6ff181554be1":"ok","9ff6547359f841daf68730db7d4e41284fa6a38c80756f86e9cef2ce48340223":"ok","6af519c91261ddd2547c136d07e23a85db031cc8a04b92d14a9f55e2bf23a0f7":"ok","825366d6aea22b4f4abd55a997f9e333aff8dc69499c4cb8208d3e9bff93710f":"ok","c872066be83c163872864f9fcdd6ac2c8a2090fb1c65dd610495dddcf10279a1":"ok","b7f194155be377e8c4b8fb3a8e8c465f6e7506b875e56c2a4bc8ef57df380641":"ok","2f17330de81032c0efaf59f47ec7434267e8d02d638977c485d2148707ce8a56":"ok","62ba3cc9354cf0df5746972926434f4198f60de938a46bb345dd2c44157a2eb5":"ok","3cb0a0652a2005645f9aae3e333b975434e100d9a0663c418177f7c3c9c0bb41":"ok","cd990ca3f6a44f125165fa57011f45a4f37c8eacf7c44c724e0b1277eddb538f":"ok"}"""
+        val validPeersResponse = """[
+   {
+      "nodeId":"03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
+      "state":"CONNECTED",
+      "address":"34.239.230.56:9735",
+      "channels":1
+   },
+   {
+      "nodeId":"039dc0e0b1d25905e44fdf6f8e89755a5e219685840d0bc1d28d3308f9628a3585",
+      "state":"DISCONNECTED",
+      "channels":1
+   }
+]"""
     }
 }
 
@@ -137,4 +153,6 @@ class FailingEclairClient(private val error: ApiError) : IEclairClient, IEclairC
         feeBaseMsat: Int,
         feeProportionalMillionths: Int
     ): Either<ApiError, String> = Either.Left(error)
+
+    override suspend fun peers(): Either<ApiError, String> = Either.Left(error)
 }


### PR DESCRIPTION
This Pull Request adds the implementation of the `peers` command.
The logs of this command are:

```
claddy@claddy:~/Documents/eclair-cli$ eclair-cli.kexe peers -p password
[
    {
        "nodeId": "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e",
        "state": "CONNECTED",
        "address": "127.0.0.1:9736",
        "channels": 12
    },
    {
        "nodeId": "039743b8b5030cf15717f855e7a4e4d15b40c0c08ed2f219c739721570baae81d5",
        "state": "CONNECTED",
        "address": "127.0.0.1:9737",
        "channels": 0
    }
]
```