### PR TITLE
Implement `node`, `nodes`, `allchannels`, and `allupdates` commands

### DIFF
--- a/contrib/eclair-cli_autocomplete.sh
+++ b/contrib/eclair-cli_autocomplete.sh
@@ -19,7 +19,7 @@ _eclair_cli() {
     # `_init_completion` is a helper function provided by the Bash-completion package.
     _init_completion || return
 
-    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node"
+    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node allchannels"
     local common_opts="-p --host"
     local connect_opts="--uri --nodeId --address --port"
     local disconnect_opts="--nodeId"

--- a/contrib/eclair-cli_autocomplete.sh
+++ b/contrib/eclair-cli_autocomplete.sh
@@ -19,7 +19,7 @@ _eclair_cli() {
     # `_init_completion` is a helper function provided by the Bash-completion package.
     _init_completion || return
 
-    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node allchannels"
+    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node allchannels allupdates"
     local common_opts="-p --host"
     local connect_opts="--uri --nodeId --address --port"
     local disconnect_opts="--nodeId"
@@ -31,6 +31,7 @@ _eclair_cli() {
     local updaterelayfee_opts="--nodeId --nodeIds --feeBaseMsat --feeProportionalMillionths"
     local nodes_opts="--nodeIds"
     local node_opts="--nodeId"
+    local allupdates_opts="--nodeId"
 
 	# If the current word starts with a dash (-), it's an option rather than a command
      if [[ ${cur} == -* ]]; then
@@ -74,6 +75,9 @@ _eclair_cli() {
                 ;;
             node)
                 COMPREPLY=( $(compgen -W "${node_opts} ${common_opts}" -- ${cur}) )
+                ;;
+            allupdates)
+                COMPREPLY=( $(compgen -W "${allupdates_opts} ${common_opts}" -- ${cur}) )
                 ;;
             *)
                 COMPREPLY=( $(compgen -W "${common_opts}" -- ${cur}) )

--- a/contrib/eclair-cli_autocomplete.sh
+++ b/contrib/eclair-cli_autocomplete.sh
@@ -19,7 +19,7 @@ _eclair_cli() {
     # `_init_completion` is a helper function provided by the Bash-completion package.
     _init_completion || return
 
-    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes"
+    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node"
     local common_opts="-p --host"
     local connect_opts="--uri --nodeId --address --port"
     local disconnect_opts="--nodeId"
@@ -30,6 +30,7 @@ _eclair_cli() {
     local forceclose_opts="--channelId --shortChannelId --channelIds --shortChannelIds"
     local updaterelayfee_opts="--nodeId --nodeIds --feeBaseMsat --feeProportionalMillionths"
     local nodes_opts="--nodeIds"
+    local node_opts="--nodeId"
 
 	# If the current word starts with a dash (-), it's an option rather than a command
      if [[ ${cur} == -* ]]; then
@@ -70,6 +71,9 @@ _eclair_cli() {
                 ;;
             nodes)
                 COMPREPLY=( $(compgen -W "${nodes_opts} ${common_opts}" -- ${cur}) )
+                ;;
+            node)
+                COMPREPLY=( $(compgen -W "${node_opts} ${common_opts}" -- ${cur}) )
                 ;;
             *)
                 COMPREPLY=( $(compgen -W "${common_opts}" -- ${cur}) )

--- a/contrib/eclair-cli_autocomplete.sh
+++ b/contrib/eclair-cli_autocomplete.sh
@@ -19,7 +19,7 @@ _eclair_cli() {
     # `_init_completion` is a helper function provided by the Bash-completion package.
     _init_completion || return
 
-    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers"
+    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes"
     local common_opts="-p --host"
     local connect_opts="--uri --nodeId --address --port"
     local disconnect_opts="--nodeId"
@@ -29,6 +29,7 @@ _eclair_cli() {
     local close_opts="--channelId --shortChannelId --channelIds --shortChannelIds --scriptPubKey --preferredFeerateSatByte --minFeerateSatByte --maxFeerateSatByte"
     local forceclose_opts="--channelId --shortChannelId --channelIds --shortChannelIds"
     local updaterelayfee_opts="--nodeId --nodeIds --feeBaseMsat --feeProportionalMillionths"
+    local nodes_opts="--nodeIds"
 
 	# If the current word starts with a dash (-), it's an option rather than a command
      if [[ ${cur} == -* ]]; then
@@ -66,6 +67,9 @@ _eclair_cli() {
                 ;;
             updaterelayfee)
                 COMPREPLY=( $(compgen -W "${updaterelayfee_opts} ${common_opts}" -- ${cur}) )
+                ;;
+            nodes)
+                COMPREPLY=( $(compgen -W "${nodes_opts} ${common_opts}" -- ${cur}) )
                 ;;
             *)
                 COMPREPLY=( $(compgen -W "${common_opts}" -- ${cur}) )

--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -22,6 +22,7 @@ fun main(args: Array<String>) {
         UpdateRelayFeeCommand(resultWriter, apiClientBuilder),
         NodesCommand(resultWriter, apiClientBuilder),
         NodeCommand(resultWriter, apiClientBuilder),
+        AllChannelsCommand(resultWriter, apiClientBuilder),
     )
     parser.parse(args)
 }

--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -23,6 +23,7 @@ fun main(args: Array<String>) {
         NodesCommand(resultWriter, apiClientBuilder),
         NodeCommand(resultWriter, apiClientBuilder),
         AllChannelsCommand(resultWriter, apiClientBuilder),
+        AllUpdatesCommand(resultWriter, apiClientBuilder),
     )
     parser.parse(args)
 }

--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -18,7 +18,9 @@ fun main(args: Array<String>) {
         CloseCommand(resultWriter, apiClientBuilder),
         ForceCloseCommand(resultWriter, apiClientBuilder),
         UpdateRelayFeeCommand(resultWriter, apiClientBuilder),
-        PeersCommand(resultWriter, apiClientBuilder)
+        PeersCommand(resultWriter, apiClientBuilder),
+        UpdateRelayFeeCommand(resultWriter, apiClientBuilder),
+        NodesCommand(resultWriter, apiClientBuilder),
     )
     parser.parse(args)
 }

--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -21,6 +21,7 @@ fun main(args: Array<String>) {
         PeersCommand(resultWriter, apiClientBuilder),
         UpdateRelayFeeCommand(resultWriter, apiClientBuilder),
         NodesCommand(resultWriter, apiClientBuilder),
+        NodeCommand(resultWriter, apiClientBuilder),
     )
     parser.parse(args)
 }

--- a/src/nativeMain/kotlin/api/EclairClient.kt
+++ b/src/nativeMain/kotlin/api/EclairClient.kt
@@ -80,6 +80,8 @@ interface IEclairClient {
     suspend fun nodes(nodeIds: List<String>?): Either<ApiError, String>
 
     suspend fun node(nodeId: String): Either<ApiError, String>
+
+    suspend fun allchannels(): Either<ApiError, String>
 }
 
 class EclairClient(private val apiHost: String, private val apiPassword: String) : IEclairClient {
@@ -361,6 +363,18 @@ class EclairClient(private val apiHost: String, private val apiPassword: String)
                     append("nodeId", nodeId)
                 }
             )
+            when (response.status) {
+                HttpStatusCode.OK -> Either.Right((response.bodyAsText()))
+                else -> Either.Left(convertHttpError(response.status))
+            }
+        } catch (e: Throwable) {
+            Either.Left(ApiError(0, e.message ?: "Unknown exception"))
+        }
+    }
+
+    override suspend fun allchannels(): Either<ApiError, String> {
+        return try {
+            val response: HttpResponse = httpClient.post("$apiHost/allchannels")
             when (response.status) {
                 HttpStatusCode.OK -> Either.Right((response.bodyAsText()))
                 else -> Either.Left(convertHttpError(response.status))

--- a/src/nativeMain/kotlin/commands/AllChannels.kt
+++ b/src/nativeMain/kotlin/commands/AllChannels.kt
@@ -1,0 +1,40 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import arrow.core.Either
+import arrow.core.flatMap
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import types.AllChannels
+import types.ApiError
+
+class AllChannelsCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "allchannels",
+    "Returns non-detailed information about all public channels in the network."
+) {
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        val result = eclairClient.allchannels()
+            .flatMap { apiResponse ->
+                try {
+                    Either.Right(format.decodeFromString<List<AllChannels>>(apiResponse))
+                } catch (e: Throwable) {
+                    Either.Left(ApiError(1, "api response could not be parsed: $apiResponse"))
+                }
+            }
+            .map { decoded ->
+                format.encodeToString(decoded)
+            }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/commands/AllUpdates.kt
+++ b/src/nativeMain/kotlin/commands/AllUpdates.kt
@@ -1,0 +1,49 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import arrow.core.Either
+import arrow.core.flatMap
+import kotlinx.cli.ArgType
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import types.AllUpdates
+import types.ApiError
+import types.Node
+
+class AllUpdatesCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "allupdates",
+    "Returns detailed information about all public channels in the network; the information is mostly taken from the channel_update network messages."
+) {
+    private val nodeId by option(
+        ArgType.String,
+        description = "The nodeId of the node to be used as filter for the updates"
+    )
+
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        val result = eclairClient.allupdates(
+            nodeId = nodeId
+        )
+            .flatMap { apiResponse ->
+                try {
+                    Either.Right(format.decodeFromString<List<AllUpdates>>(apiResponse))
+                } catch (e: Throwable) {
+                    Either.Left(ApiError(1, "api response could not be parsed: $apiResponse"))
+                }
+            }
+            .map { decoded ->
+                format.encodeToString(decoded)
+            }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/commands/Node.kt
+++ b/src/nativeMain/kotlin/commands/Node.kt
@@ -1,0 +1,32 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import arrow.core.flatMap
+import kotlinx.cli.ArgType
+import kotlinx.coroutines.runBlocking
+import types.NodeCommandResponse
+import types.Serialization
+
+class NodeCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "node",
+    "Returns information about a specific node on the lightning network, including its node_announcement and some channel statistics."
+) {
+    private val nodeId by option(
+        ArgType.String,
+        description = "The nodeId of the requested node"
+    )
+
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val result = eclairClient.node(
+            nodeId = nodeId!!,
+        )
+            .flatMap { apiResponse -> Serialization.decode<NodeCommandResponse>(apiResponse) }
+            .map { decoded -> Serialization.encode(decoded) }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/commands/Nodes.kt
+++ b/src/nativeMain/kotlin/commands/Nodes.kt
@@ -1,0 +1,48 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import arrow.core.Either
+import arrow.core.flatMap
+import kotlinx.cli.ArgType
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import types.ApiError
+import types.Node
+
+class NodesCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "nodes",
+    "Returns information about public nodes on the lightning network; this information is taken from the node_announcement network message."
+) {
+    private val nodeIds by option(
+        ArgType.String,
+        description = "The nodeIds of the nodes to return"
+    )
+
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        val result = eclairClient.nodes(
+            nodeIds = nodeIds?.split(","),
+        )
+            .flatMap { apiResponse ->
+                try {
+                    Either.Right(format.decodeFromString<List<Node>>(apiResponse))
+                } catch (e: Throwable) {
+                    Either.Left(ApiError(1, "api response could not be parsed: $apiResponse"))
+                }
+            }
+            .map { decoded ->
+                format.encodeToString(decoded)
+            }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/types/EclairApiTypes.kt
+++ b/src/nativeMain/kotlin/types/EclairApiTypes.kt
@@ -56,3 +56,8 @@ data class Timestamp(
     val iso: String,
     val unix: Long
 )
+
+@Serializable
+data class NodeCommandResponse(
+    val announcement: Node
+) : EclairApiType()

--- a/src/nativeMain/kotlin/types/EclairApiTypes.kt
+++ b/src/nativeMain/kotlin/types/EclairApiTypes.kt
@@ -1,5 +1,6 @@
 package types
 
+import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 
 data class ApiError(val code: Int, val message: String)
@@ -36,4 +37,22 @@ data class Peer(
     val state: String,
     val address: String? = null,
     val channels: Int
+)
+
+@Serializable
+data class Node(
+    val signature: String,
+    val features: Features,
+    val timestamp: Timestamp,
+    val nodeId: String,
+    val rgbColor: String,
+    val alias: String,
+    val addresses: List<String>,
+    val tlvStream: Map<String, @Contextual Any>
+)
+
+@Serializable
+data class Timestamp(
+    val iso: String,
+    val unix: Long
 )

--- a/src/nativeMain/kotlin/types/EclairApiTypes.kt
+++ b/src/nativeMain/kotlin/types/EclairApiTypes.kt
@@ -68,3 +68,25 @@ data class AllChannels(
     val a: String,
     val b: String
 )
+
+@Serializable
+data class AllUpdates(
+    val signature: String,
+    val chainHash: String,
+    val shortChannelId: String,
+    val timestamp: Timestamp,
+    val messageFlags: Map<String, Boolean>,
+    val channelFlags: ChannelFlags,
+    val cltvExpiryDelta: Int,
+    val htlcMinimumMsat: Int,
+    val feeBaseMsat: Int,
+    val feeProportionalMillionths: Int,
+    val htlcMaximumMsat: Long,
+    val tlvStream: Map<String, @Contextual Any>
+)
+
+@Serializable
+data class ChannelFlags(
+    val isEnabled: Boolean,
+    val isNode1: Boolean
+)

--- a/src/nativeMain/kotlin/types/EclairApiTypes.kt
+++ b/src/nativeMain/kotlin/types/EclairApiTypes.kt
@@ -61,3 +61,10 @@ data class Timestamp(
 data class NodeCommandResponse(
     val announcement: Node
 ) : EclairApiType()
+
+@Serializable
+data class AllChannels(
+    val shortChannelId: String,
+    val a: String,
+    val b: String
+)

--- a/src/nativeTest/kotlin/commands/AllChannelsTest.kt
+++ b/src/nativeTest/kotlin/commands/AllChannelsTest.kt
@@ -1,0 +1,55 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import kotlinx.serialization.json.Json
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import kotlin.test.*
+
+class AllChannelsCommandTest {
+    @OptIn(ExperimentalCli::class)
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = AllChannelsCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(arrayOf("allchannels", "-p", "password"))
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter = runTest(DummyEclairClient(allChannelsResponse = DummyEclairClient.validAllChannelsResponse))
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        assertEquals(
+            format.parseToJsonElement(DummyEclairClient.validAllChannelsResponse),
+            format.decodeFromString(resultWriter.lastResult!!),
+        )
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+
+    @Test
+    fun `serialization error`() {
+        val resultWriter = runTest(DummyEclairClient(allChannelsResponse = "{invalidJson}"))
+        assertNull(resultWriter.lastResult)
+        assertNotNull(resultWriter.lastError)
+        assertTrue(resultWriter.lastError!!.message.contains("api response could not be parsed"))
+    }
+}

--- a/src/nativeTest/kotlin/commands/AllUpdatesTest.kt
+++ b/src/nativeTest/kotlin/commands/AllUpdatesTest.kt
@@ -1,0 +1,55 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import kotlinx.serialization.json.Json
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import kotlin.test.*
+
+class AllUpdatesCommandTest {
+    @OptIn(ExperimentalCli::class)
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = AllUpdatesCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(arrayOf("allupdates", "-p", "password", "--nodeId", "03c5b161c16e9f8ef3f3bccfb74a6e9a3b423dd41fe2848174b7209f1c2ea25dad"))
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter = runTest(DummyEclairClient(allUpdatesResponse = DummyEclairClient.validAllUpdatesResponse))
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        assertEquals(
+            format.parseToJsonElement(DummyEclairClient.validAllUpdatesResponse),
+            format.decodeFromString(resultWriter.lastResult!!),
+        )
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+
+    @Test
+    fun `serialization error`() {
+        val resultWriter = runTest(DummyEclairClient(allUpdatesResponse = "{invalidJson}"))
+        assertNull(resultWriter.lastResult)
+        assertNotNull(resultWriter.lastError)
+        assertTrue(resultWriter.lastError!!.message.contains("api response could not be parsed"))
+    }
+}

--- a/src/nativeTest/kotlin/commands/NodeTest.kt
+++ b/src/nativeTest/kotlin/commands/NodeTest.kt
@@ -1,0 +1,52 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import kotlinx.serialization.json.Json
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import types.NodeCommandResponse
+import kotlin.test.*
+
+class NodeCommandTest {
+    @OptIn(ExperimentalCli::class)
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = NodeCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(arrayOf("node", "-p", "password", "--nodeId", "03c5b161c16e9f8ef3f3bccfb74a6e9a3b423dd41fe2848174b7209f1c2ea25dad"))
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter = runTest(DummyEclairClient(nodeResponse = DummyEclairClient.validNodeResponse))
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        val format = Json { ignoreUnknownKeys = true }
+        assertEquals(
+            format.decodeFromString(NodeCommandResponse.serializer(), DummyEclairClient.validNodeResponse),
+            format.decodeFromString(NodeCommandResponse.serializer(), resultWriter.lastResult!!),
+        )
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+
+    @Test
+    fun `serialization error`() {
+        val resultWriter = runTest(DummyEclairClient(nodeResponse = "{invalidJson}"))
+        assertNull(resultWriter.lastResult)
+        assertNotNull(resultWriter.lastError)
+        assertTrue(resultWriter.lastError!!.message.contains("api response could not be parsed"))
+    }
+}

--- a/src/nativeTest/kotlin/commands/NodesTest.kt
+++ b/src/nativeTest/kotlin/commands/NodesTest.kt
@@ -1,0 +1,55 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import kotlinx.serialization.json.Json
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import kotlin.test.*
+
+class NodesCommandTest {
+    @OptIn(ExperimentalCli::class)
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = NodesCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(arrayOf("nodes", "-p", "password", "--nodeIds", "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e,03c5b161c16e9f8ef3f3bccfb74a6e9a3b423dd41fe2848174b7209f1c2ea25dad"))
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter = runTest(DummyEclairClient(nodesResponse = DummyEclairClient.validNodesResponse))
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        assertEquals(
+            format.parseToJsonElement(DummyEclairClient.validNodesResponse),
+            format.decodeFromString(resultWriter.lastResult!!),
+        )
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+
+    @Test
+    fun `serialization error`() {
+        val resultWriter = runTest(DummyEclairClient(nodesResponse = "{invalidJson}"))
+        assertNull(resultWriter.lastResult)
+        assertNotNull(resultWriter.lastError)
+        assertTrue(resultWriter.lastError!!.message.contains("api response could not be parsed"))
+    }
+}

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -19,6 +19,7 @@ class DummyEclairClient(
     private val peersResponse: String = validPeersResponse,
     private val nodesResponse: String = validNodesResponse,
     private val nodeResponse: String = validNodeResponse,
+    private val allChannelsResponse: String = validAllChannelsResponse,
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
@@ -74,6 +75,7 @@ class DummyEclairClient(
 
     override suspend fun node(nodeId: String): Either<ApiError, String> = Either.Right(nodeResponse)
 
+    override suspend fun allchannels(): Either<ApiError, String> = Either.Right(allChannelsResponse)
 
     companion object {
         val validGetInfoResponse =
@@ -211,6 +213,18 @@ class DummyEclairClient(
   }
 }
 """
+        val validAllChannelsResponse = """[
+  {
+    "shortChannelId": "508856x657x0",
+    "a": "0206c7b60457550f512d80ecdd9fb6eb798ce7e91bf6ec08ad9c53d72e94ef620d",
+    "b": "02f6725f9c1c40333b67faea92fd211c183050f28df32cac3f9d69685fe9665432"
+  },
+  {
+    "shortChannelId": "512733x303x0",
+    "a": "024bd94f0425590434538fd21d4e58982f7e9cfd8f339205a73deb9c0e0341f5bd",
+    "b": "02eae56f155bae8a8eaab82ddc6fef04d5a79a6b0b0d7bcdd0b60d52f3015af031"
+  }
+]"""
     }
 }
 
@@ -268,4 +282,6 @@ class FailingEclairClient(private val error: ApiError) : IEclairClient, IEclairC
     override suspend fun nodes(nodeIds: List<String>?): Either<ApiError, String> = Either.Left(error)
 
     override suspend fun node(nodeId: String): Either<ApiError, String> = Either.Left(error)
+
+    override suspend fun allchannels(): Either<ApiError, String> = Either.Left(error)
 }

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -18,6 +18,7 @@ class DummyEclairClient(
     private val updateRelayFeeResponse: String = validUpdateRelayFeeResponse,
     private val peersResponse: String = validPeersResponse,
     private val nodesResponse: String = validNodesResponse,
+    private val nodeResponse: String = validNodeResponse,
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
@@ -70,6 +71,9 @@ class DummyEclairClient(
     override suspend fun peers(): Either<ApiError, String> = Either.Right(peersResponse)
 
     override suspend fun nodes(nodeIds: List<String>?): Either<ApiError, String> = Either.Right(nodesResponse)
+
+    override suspend fun node(nodeId: String): Either<ApiError, String> = Either.Right(nodeResponse)
+
 
     companion object {
         val validGetInfoResponse =
@@ -170,6 +174,43 @@ class DummyEclairClient(
     "tlvStream": {}
   }
 ]"""
+        val validNodeResponse = """{
+  "type": "types.NodeCommandResponse",
+  "announcement": {
+    "signature": "327c3bd0933e98bd5e65d24e1e1f6aae310f8c1606544dba6cb587b95542d9111eb9abf0a34283ef007e04ed7b003bef3bdb74896a8e34fe86b0fb0734f7efc7",
+    "features": {
+      "activated": {
+        "gossip_queries_ex": "optional",
+        "option_data_loss_protect": "optional",
+        "var_onion_optin": "mandatory",
+        "option_static_remotekey": "optional",
+        "option_scid_alias": "optional",
+        "option_onion_messages": "optional",
+        "option_support_large_channel": "optional",
+        "option_anchors_zero_fee_htlc_tx": "optional",
+        "payment_secret": "mandatory",
+        "option_shutdown_anysegwit": "optional",
+        "option_channel_type": "optional",
+        "basic_mpp": "optional",
+        "gossip_queries": "optional"
+      },
+      "unknown": [
+      ]
+    },
+    "timestamp": {
+      "iso": "2023-08-14T10:27:13Z",
+      "unix": 1692008833
+    },
+    "nodeId": "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e",
+    "rgbColor": "#49daaa",
+    "alias": "bob",
+    "addresses": [
+    ],
+    "tlvStream": {
+    }
+  }
+}
+"""
     }
 }
 
@@ -225,4 +266,6 @@ class FailingEclairClient(private val error: ApiError) : IEclairClient, IEclairC
     override suspend fun peers(): Either<ApiError, String> = Either.Left(error)
 
     override suspend fun nodes(nodeIds: List<String>?): Either<ApiError, String> = Either.Left(error)
+
+    override suspend fun node(nodeId: String): Either<ApiError, String> = Either.Left(error)
 }

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -20,6 +20,7 @@ class DummyEclairClient(
     private val nodesResponse: String = validNodesResponse,
     private val nodeResponse: String = validNodeResponse,
     private val allChannelsResponse: String = validAllChannelsResponse,
+    private val allUpdatesResponse: String = validAllUpdatesResponse,
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
@@ -76,6 +77,8 @@ class DummyEclairClient(
     override suspend fun node(nodeId: String): Either<ApiError, String> = Either.Right(nodeResponse)
 
     override suspend fun allchannels(): Either<ApiError, String> = Either.Right(allChannelsResponse)
+
+    override suspend fun allupdates(nodeId: String?): Either<ApiError, String> = Either.Right(allUpdatesResponse)
 
     companion object {
         val validGetInfoResponse =
@@ -225,6 +228,52 @@ class DummyEclairClient(
     "b": "02eae56f155bae8a8eaab82ddc6fef04d5a79a6b0b0d7bcdd0b60d52f3015af031"
   }
 ]"""
+        val validAllUpdatesResponse = """[
+  {
+    "signature": "02bbe4ee3f128ba044937428680d266c71231fd02d899c446aad498ca095610133f7c2ddb68ed0d8d29961d0962651556dc08b5cb00fb56055d2b98407f4addb",
+    "chainHash": "06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f",
+    "shortChannelId": "2899x1x1",
+    "timestamp": {
+      "iso": "2022-02-01T12:27:50Z",
+      "unix": 1643718470
+    },
+    "messageFlags": {
+      "dontForward": false
+    },
+    "channelFlags": {
+      "isEnabled": true,
+      "isNode1": true
+    },
+    "cltvExpiryDelta": 48,
+    "htlcMinimumMsat": 1,
+    "feeBaseMsat": 5,
+    "feeProportionalMillionths": 150,
+    "htlcMaximumMsat": 450000000,
+    "tlvStream": {}
+  },
+  {
+    "signature": "1da0e7094424c0daa64fe8427e191095d14285dd9346f37d014d07d8857b53cc6bed703d22794ddbfc1945cf5bdb7566137441964e01f8facc30c17fd0dffa06",
+    "chainHash": "06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f",
+    "shortChannelId": "2899x1x1",
+    "timestamp": {
+      "iso": "2022-02-01T12:27:19Z",
+      "unix": 1643718439
+    },
+    "messageFlags": {
+      "dontForward": false
+    },
+    "channelFlags": {
+      "isEnabled": false,
+      "isNode1": false
+    },
+    "cltvExpiryDelta": 48,
+    "htlcMinimumMsat": 1,
+    "feeBaseMsat": 1000,
+    "feeProportionalMillionths": 200,
+    "htlcMaximumMsat": 450000000,
+    "tlvStream": {}
+  }
+]"""
     }
 }
 
@@ -284,4 +333,6 @@ class FailingEclairClient(private val error: ApiError) : IEclairClient, IEclairC
     override suspend fun node(nodeId: String): Either<ApiError, String> = Either.Left(error)
 
     override suspend fun allchannels(): Either<ApiError, String> = Either.Left(error)
+
+    override suspend fun allupdates(nodeId: String?): Either<ApiError, String> = Either.Left(error)
 }

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -17,6 +17,7 @@ class DummyEclairClient(
     private val forcecloseResponse: String = validForceCloseResponse,
     private val updateRelayFeeResponse: String = validUpdateRelayFeeResponse,
     private val peersResponse: String = validPeersResponse,
+    private val nodesResponse: String = validNodesResponse,
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
@@ -68,6 +69,8 @@ class DummyEclairClient(
 
     override suspend fun peers(): Either<ApiError, String> = Either.Right(peersResponse)
 
+    override suspend fun nodes(nodeIds: List<String>?): Either<ApiError, String> = Either.Right(nodesResponse)
+
     companion object {
         val validGetInfoResponse =
             """{"version":"0.9.0","nodeId":"03e319aa4ecc7a89fb8b3feb6efe9075864b91048bff5bef14efd55a69760ddf17","alias":"alice","color":"#49daaa","features":{"activated":{"var_onion_optin":"mandatory","option_static_remotekey":"optional"},"unknown":[151,178]},"chainHash":"06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f","network":"regtest","blockHeight":107,"publicAddresses":[],"instanceId":"be74bd9a-fc54-4f24-bc41-0477c9ce2fb4"}"""
@@ -101,6 +104,71 @@ class DummyEclairClient(
       "state":"DISCONNECTED",
       "channels":1
    }
+]"""
+        val validNodesResponse = """[
+  {
+    "signature": "c466c08fa16c1810e2971de2a57ef1f9e5e13d36a224544cf0e3d621030b9e617652b88fb2024bfdc60066ca63b4f67504f154e8fee7f13bc39739b76cc4419f",
+    "features": {
+      "activated": {
+        "option_onion_messages": "optional",
+        "gossip_queries_ex": "optional",
+        "option_data_loss_protect": "optional",
+        "var_onion_optin": "mandatory",
+        "option_static_remotekey": "optional",
+        "option_support_large_channel": "optional",
+        "option_anchors_zero_fee_htlc_tx": "optional",
+        "payment_secret": "mandatory",
+        "option_shutdown_anysegwit": "optional",
+        "option_channel_type": "optional",
+        "basic_mpp": "optional",
+        "gossip_queries": "optional"
+      },
+      "unknown": []
+    },
+    "timestamp": {
+      "iso": "2022-02-01T12:27:19Z",
+      "unix": 1643718439
+    },
+    "nodeId": "028e2403fbfddb3d787843361f91adbda64c6f622921b19fb48f5766508bcadb29",
+    "rgbColor": "#49daaa",
+    "alias": "alice",
+    "addresses": [
+      "138.229.205.237:9735"
+    ],
+    "tlvStream": {}
+  },
+  {
+    "signature": "f6cce33383fe1291fa60cfa7d9efa4a45c081396e445e9cadc825ab695aab30308a68733d27fc54a5c46b888bdddd467f30f2f5441e95c2920b3b6c54decc3a1",
+    "features": {
+      "activated": {
+        "option_onion_messages": "optional",
+        "gossip_queries_ex": "optional",
+        "option_data_loss_protect": "optional",
+        "var_onion_optin": "mandatory",
+        "option_static_remotekey": "optional",
+        "option_support_large_channel": "optional",
+        "option_anchors_zero_fee_htlc_tx": "optional",
+        "payment_secret": "mandatory",
+        "option_shutdown_anysegwit": "optional",
+        "option_channel_type": "optional",
+        "basic_mpp": "optional",
+        "gossip_queries": "optional"
+      },
+      "unknown": []
+    },
+    "timestamp": {
+      "iso": "2022-02-01T12:27:19Z",
+      "unix": 1643718439
+    },
+    "nodeId": "02fe677ac8cd61399d097535a3e8a51a0849e57cdbab9b34796c86f3e33568cbe2",
+    "rgbColor": "#49daaa",
+    "alias": "bob",
+    "addresses": [
+      "95.216.16.21:9735",
+      "[2a01:4f9:2a:106a:0:0:0:2]:9736"
+    ],
+    "tlvStream": {}
+  }
 ]"""
     }
 }
@@ -155,4 +223,6 @@ class FailingEclairClient(private val error: ApiError) : IEclairClient, IEclairC
     ): Either<ApiError, String> = Either.Left(error)
 
     override suspend fun peers(): Either<ApiError, String> = Either.Left(error)
+
+    override suspend fun nodes(nodeIds: List<String>?): Either<ApiError, String> = Either.Left(error)
 }


### PR DESCRIPTION
All the command given under [Network section](https://acinq.github.io/eclair/#network) of eclair API Documentation are implemented in this PR. 
The logs (just for reference are given below in comments)