### PR TITLE
Implement cli methods for `Payments` section of eclair API

### DIFF
--- a/contrib/eclair-cli_autocomplete.sh
+++ b/contrib/eclair-cli_autocomplete.sh
@@ -19,7 +19,7 @@ _eclair_cli() {
     # `_init_completion` is a helper function provided by the Bash-completion package.
     _init_completion || return
 
-    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node allchannels allupdates createinvoice deleteinvoice parseinvoice payinvoice"
+    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node allchannels allupdates createinvoice deleteinvoice parseinvoice payinvoice sendtonode"
     local common_opts="-p --host"
     local connect_opts="--uri --nodeId --address --port"
     local disconnect_opts="--nodeId"
@@ -36,6 +36,7 @@ _eclair_cli() {
     local deleteinvoice_opts="--paymentHash"
     local parseinvoice_opts="--invoice"
     local payinvoice_opts="--invoice --amountMsat --maxAttempts --maxFeeFlatSat --maxFeePct --externalId --pathFindingExperimentName --blocking"
+    local sendtonode_opts="--nodeId --amountMsat --maxAttempts --maxFeeFlatSat --maxFeePct --externalId --pathFindingExperimentName"
 
 	# If the current word starts with a dash (-), it's an option rather than a command
      if [[ ${cur} == -* ]]; then
@@ -94,6 +95,9 @@ _eclair_cli() {
                ;;
             payinvoice)
                 COMPREPLY=( $(compgen -W "${payinvoice_opts} ${common_opts}" -- ${cur}) )
+                ;;
+            sendtonode)
+                COMPREPLY=( $(compgen -W "${sendtonode_opts} ${common_opts}" -- ${cur}) )
                 ;;
             *)
                 COMPREPLY=( $(compgen -W "${common_opts}" -- ${cur}) )

--- a/contrib/eclair-cli_autocomplete.sh
+++ b/contrib/eclair-cli_autocomplete.sh
@@ -19,7 +19,7 @@ _eclair_cli() {
     # `_init_completion` is a helper function provided by the Bash-completion package.
     _init_completion || return
 
-    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node allchannels allupdates createinvoice deleteinvoice parseinvoice payinvoice sendtonode sendtoroute"
+    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node allchannels allupdates createinvoice deleteinvoice parseinvoice payinvoice sendtonode sendtoroute getsentinfo getreceivedinfo listreceivedpayments getinvoice listinvoices listpendinginvoices"
     local common_opts="-p --host"
     local connect_opts="--uri --nodeId --address --port"
     local disconnect_opts="--nodeId"
@@ -38,6 +38,12 @@ _eclair_cli() {
     local payinvoice_opts="--invoice --amountMsat --maxAttempts --maxFeeFlatSat --maxFeePct --externalId --pathFindingExperimentName --blocking"
     local sendtonode_opts="--nodeId --amountMsat --maxAttempts --maxFeeFlatSat --maxFeePct --externalId --pathFindingExperimentName"
     local sendtoroute_opts="--invoice --nodeIds --shortChannelIds --amountMsat --paymentHash --finalCltvExpiry --maxFeeMsat --recipientAmountMsat --parentId --externalId"
+    local getsentinfo_opts="--paymentHash --id"
+    local getreceivedinfo_opts="--paymentHash --invoice"
+    local listreceivedpayments_opts="--from --to --count --skip"
+    local getinvoice_opts="--paymentHash"
+    local listinvoices_opts="--from --to --count --skip"
+    local listpendinginvoices_opts="--from --to --count --skip"
     	# If the current word starts with a dash (-), it's an option rather than a command
      if [[ ${cur} == -* ]]; then
         local cmd=""
@@ -101,6 +107,24 @@ _eclair_cli() {
                 ;;
             sendtoroute)
                 COMPREPLY=( $(compgen -W "${sendtoroute_opts} ${common_opts}" -- ${cur}) )
+                ;;
+            getsentinfo)
+                COMPREPLY=( $(compgen -W "${getsentinfo_opts} ${common_opts}" -- ${cur}) )
+                ;;
+            getreceivedinfo)
+                COMPREPLY=( $(compgen -W "${getreceivedinfo_opts} ${common_opts}" -- ${cur}) )
+                ;;
+            listreceivedpayments)
+                COMPREPLY=( $(compgen -W "${listreceivedpayments_opts} ${common_opts}" -- ${cur}) )
+                ;;
+            getinvoice)
+                COMPREPLY=( $(compgen -W "${getinvoice_opts} ${common_opts}" -- ${cur}) )
+                ;;
+            listinvoices)
+                COMPREPLY=( $(compgen -W "${listinvoices_opts} ${common_opts}" -- ${cur}) )
+                ;;
+            listpendinginvoices)
+                COMPREPLY=( $(compgen -W "${listpendinginvoices_opts} ${common_opts}" -- ${cur}) )
                 ;;
             *)
                 COMPREPLY=( $(compgen -W "${common_opts}" -- ${cur}) )

--- a/contrib/eclair-cli_autocomplete.sh
+++ b/contrib/eclair-cli_autocomplete.sh
@@ -19,7 +19,7 @@ _eclair_cli() {
     # `_init_completion` is a helper function provided by the Bash-completion package.
     _init_completion || return
 
-    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node allchannels allupdates"
+    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node allchannels allupdates createinvoice"
     local common_opts="-p --host"
     local connect_opts="--uri --nodeId --address --port"
     local disconnect_opts="--nodeId"
@@ -32,6 +32,7 @@ _eclair_cli() {
     local nodes_opts="--nodeIds"
     local node_opts="--nodeId"
     local allupdates_opts="--nodeId"
+    local createinvoice_opts="--description --descriptionHash --amountMsat --expireIn --fallbackAddress --paymentPreimage"
 
 	# If the current word starts with a dash (-), it's an option rather than a command
      if [[ ${cur} == -* ]]; then
@@ -78,6 +79,9 @@ _eclair_cli() {
                 ;;
             allupdates)
                 COMPREPLY=( $(compgen -W "${allupdates_opts} ${common_opts}" -- ${cur}) )
+                ;;
+            createinvoice)
+                COMPREPLY=( $(compgen -W "${createinvoice_opts} ${common_opts}" -- ${cur}) )
                 ;;
             *)
                 COMPREPLY=( $(compgen -W "${common_opts}" -- ${cur}) )

--- a/contrib/eclair-cli_autocomplete.sh
+++ b/contrib/eclair-cli_autocomplete.sh
@@ -19,7 +19,7 @@ _eclair_cli() {
     # `_init_completion` is a helper function provided by the Bash-completion package.
     _init_completion || return
 
-    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node allchannels allupdates createinvoice deleteinvoice parseinvoice payinvoice sendtonode"
+    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node allchannels allupdates createinvoice deleteinvoice parseinvoice payinvoice sendtonode sendtoroute"
     local common_opts="-p --host"
     local connect_opts="--uri --nodeId --address --port"
     local disconnect_opts="--nodeId"
@@ -37,8 +37,8 @@ _eclair_cli() {
     local parseinvoice_opts="--invoice"
     local payinvoice_opts="--invoice --amountMsat --maxAttempts --maxFeeFlatSat --maxFeePct --externalId --pathFindingExperimentName --blocking"
     local sendtonode_opts="--nodeId --amountMsat --maxAttempts --maxFeeFlatSat --maxFeePct --externalId --pathFindingExperimentName"
-
-	# If the current word starts with a dash (-), it's an option rather than a command
+    local sendtoroute_opts="--invoice --nodeIds --shortChannelIds --amountMsat --paymentHash --finalCltvExpiry --maxFeeMsat --recipientAmountMsat --parentId --externalId"
+    	# If the current word starts with a dash (-), it's an option rather than a command
      if [[ ${cur} == -* ]]; then
         local cmd=""
         for ((i=$cword; i>0; i--)); do
@@ -98,6 +98,9 @@ _eclair_cli() {
                 ;;
             sendtonode)
                 COMPREPLY=( $(compgen -W "${sendtonode_opts} ${common_opts}" -- ${cur}) )
+                ;;
+            sendtoroute)
+                COMPREPLY=( $(compgen -W "${sendtoroute_opts} ${common_opts}" -- ${cur}) )
                 ;;
             *)
                 COMPREPLY=( $(compgen -W "${common_opts}" -- ${cur}) )

--- a/contrib/eclair-cli_autocomplete.sh
+++ b/contrib/eclair-cli_autocomplete.sh
@@ -19,7 +19,7 @@ _eclair_cli() {
     # `_init_completion` is a helper function provided by the Bash-completion package.
     _init_completion || return
 
-    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node allchannels allupdates createinvoice deleteinvoice parseinvoice"
+    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node allchannels allupdates createinvoice deleteinvoice parseinvoice payinvoice"
     local common_opts="-p --host"
     local connect_opts="--uri --nodeId --address --port"
     local disconnect_opts="--nodeId"
@@ -35,6 +35,7 @@ _eclair_cli() {
     local createinvoice_opts="--description --descriptionHash --amountMsat --expireIn --fallbackAddress --paymentPreimage"
     local deleteinvoice_opts="--paymentHash"
     local parseinvoice_opts="--invoice"
+    local payinvoice_opts="--invoice --amountMsat --maxAttempts --maxFeeFlatSat --maxFeePct --externalId --pathFindingExperimentName --blocking"
 
 	# If the current word starts with a dash (-), it's an option rather than a command
      if [[ ${cur} == -* ]]; then
@@ -91,6 +92,9 @@ _eclair_cli() {
             parseinvoice)
                 COMPREPLY=( $(compgen -W "${parseinvoice_opts} ${common_opts}" -- ${cur}) )
                ;;
+            payinvoice)
+                COMPREPLY=( $(compgen -W "${payinvoice_opts} ${common_opts}" -- ${cur}) )
+                ;;
             *)
                 COMPREPLY=( $(compgen -W "${common_opts}" -- ${cur}) )
                 ;;

--- a/contrib/eclair-cli_autocomplete.sh
+++ b/contrib/eclair-cli_autocomplete.sh
@@ -19,7 +19,7 @@ _eclair_cli() {
     # `_init_completion` is a helper function provided by the Bash-completion package.
     _init_completion || return
 
-    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node allchannels allupdates createinvoice deleteinvoice"
+    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node allchannels allupdates createinvoice deleteinvoice parseinvoice"
     local common_opts="-p --host"
     local connect_opts="--uri --nodeId --address --port"
     local disconnect_opts="--nodeId"
@@ -34,6 +34,7 @@ _eclair_cli() {
     local allupdates_opts="--nodeId"
     local createinvoice_opts="--description --descriptionHash --amountMsat --expireIn --fallbackAddress --paymentPreimage"
     local deleteinvoice_opts="--paymentHash"
+    local parseinvoice_opts="--invoice"
 
 	# If the current word starts with a dash (-), it's an option rather than a command
      if [[ ${cur} == -* ]]; then
@@ -87,6 +88,9 @@ _eclair_cli() {
             deleteinvoice)
                 COMPREPLY=( $(compgen -W "${deleteinvoice_opts} ${common_opts}" -- ${cur}) )
                 ;;
+            parseinvoice)
+                COMPREPLY=( $(compgen -W "${parseinvoice_opts} ${common_opts}" -- ${cur}) )
+               ;;
             *)
                 COMPREPLY=( $(compgen -W "${common_opts}" -- ${cur}) )
                 ;;

--- a/contrib/eclair-cli_autocomplete.sh
+++ b/contrib/eclair-cli_autocomplete.sh
@@ -19,7 +19,7 @@ _eclair_cli() {
     # `_init_completion` is a helper function provided by the Bash-completion package.
     _init_completion || return
 
-    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node allchannels allupdates createinvoice"
+    local commands="getinfo connect disconnect open rbfopen cpfpbumpfees close forceclose updaterelayfee peers nodes node allchannels allupdates createinvoice deleteinvoice"
     local common_opts="-p --host"
     local connect_opts="--uri --nodeId --address --port"
     local disconnect_opts="--nodeId"
@@ -33,6 +33,7 @@ _eclair_cli() {
     local node_opts="--nodeId"
     local allupdates_opts="--nodeId"
     local createinvoice_opts="--description --descriptionHash --amountMsat --expireIn --fallbackAddress --paymentPreimage"
+    local deleteinvoice_opts="--paymentHash"
 
 	# If the current word starts with a dash (-), it's an option rather than a command
      if [[ ${cur} == -* ]]; then
@@ -82,6 +83,9 @@ _eclair_cli() {
                 ;;
             createinvoice)
                 COMPREPLY=( $(compgen -W "${createinvoice_opts} ${common_opts}" -- ${cur}) )
+                ;;
+            deleteinvoice)
+                COMPREPLY=( $(compgen -W "${deleteinvoice_opts} ${common_opts}" -- ${cur}) )
                 ;;
             *)
                 COMPREPLY=( $(compgen -W "${common_opts}" -- ${cur}) )

--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -27,6 +27,7 @@ fun main(args: Array<String>) {
         CreateInvoiceCommand(resultWriter, apiClientBuilder),
         DeleteInvoiceCommand(resultWriter, apiClientBuilder),
         ParseInvoiceCommand(resultWriter, apiClientBuilder),
+        PayInvoiceCommand(resultWriter, apiClientBuilder),
     )
     parser.parse(args)
 }

--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -25,6 +25,7 @@ fun main(args: Array<String>) {
         AllChannelsCommand(resultWriter, apiClientBuilder),
         AllUpdatesCommand(resultWriter, apiClientBuilder),
         CreateInvoiceCommand(resultWriter, apiClientBuilder),
+        DeleteInvoiceCommand(resultWriter, apiClientBuilder),
     )
     parser.parse(args)
 }

--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -24,6 +24,7 @@ fun main(args: Array<String>) {
         NodeCommand(resultWriter, apiClientBuilder),
         AllChannelsCommand(resultWriter, apiClientBuilder),
         AllUpdatesCommand(resultWriter, apiClientBuilder),
+        CreateInvoiceCommand(resultWriter, apiClientBuilder),
     )
     parser.parse(args)
 }

--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -29,6 +29,7 @@ fun main(args: Array<String>) {
         ParseInvoiceCommand(resultWriter, apiClientBuilder),
         PayInvoiceCommand(resultWriter, apiClientBuilder),
         SendToNodeCommand(resultWriter, apiClientBuilder),
+        SendToRouteCommand(resultWriter, apiClientBuilder),
     )
     parser.parse(args)
 }

--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -30,6 +30,12 @@ fun main(args: Array<String>) {
         PayInvoiceCommand(resultWriter, apiClientBuilder),
         SendToNodeCommand(resultWriter, apiClientBuilder),
         SendToRouteCommand(resultWriter, apiClientBuilder),
+        GetSentInfoCommand(resultWriter, apiClientBuilder),
+        GetReceivedInfoCommand(resultWriter, apiClientBuilder),
+        ListReceivedPaymentsCommand(resultWriter, apiClientBuilder),
+        GetInvoiceCommand(resultWriter, apiClientBuilder),
+        ListInvoicesCommand(resultWriter, apiClientBuilder),
+        ListPendingInvoicesCommand(resultWriter, apiClientBuilder)
     )
     parser.parse(args)
 }

--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -26,6 +26,7 @@ fun main(args: Array<String>) {
         AllUpdatesCommand(resultWriter, apiClientBuilder),
         CreateInvoiceCommand(resultWriter, apiClientBuilder),
         DeleteInvoiceCommand(resultWriter, apiClientBuilder),
+        ParseInvoiceCommand(resultWriter, apiClientBuilder),
     )
     parser.parse(args)
 }

--- a/src/nativeMain/kotlin/Main.kt
+++ b/src/nativeMain/kotlin/Main.kt
@@ -28,6 +28,7 @@ fun main(args: Array<String>) {
         DeleteInvoiceCommand(resultWriter, apiClientBuilder),
         ParseInvoiceCommand(resultWriter, apiClientBuilder),
         PayInvoiceCommand(resultWriter, apiClientBuilder),
+        SendToNodeCommand(resultWriter, apiClientBuilder),
     )
     parser.parse(args)
 }

--- a/src/nativeMain/kotlin/api/EclairClient.kt
+++ b/src/nativeMain/kotlin/api/EclairClient.kt
@@ -131,6 +131,28 @@ interface IEclairClient {
         parentId: String?,
         externalId: String?
     ): Either<ApiError, String>
+
+    suspend fun getsentinfo(paymentHash: String, id: String?): Either<ApiError, String>
+
+    suspend fun getreceivedinfo(paymentHash: String?, invoice: String?): Either<ApiError, String>
+
+    suspend fun listreceivedpayments(from: Int?, to: Int?, count: Int?, skip: Int?): Either<ApiError, String>
+
+    suspend fun getinvoice(paymentHash: String): Either<ApiError, String>
+
+    suspend fun listinvoices(
+        from: Int?,
+        to: Int?,
+        count: Int?,
+        skip: Int?
+    ): Either<ApiError, String>
+
+    suspend fun listpendinginvoices(
+        from: Int?,
+        to: Int?,
+        count: Int?,
+        skip: Int?
+    ): Either<ApiError, String>
 }
 
 class EclairClient(private val apiHost: String, private val apiPassword: String) : IEclairClient {
@@ -603,6 +625,119 @@ class EclairClient(private val apiHost: String, private val apiPassword: String)
                     recipientAmountMsat?.let { append("recipientAmountMsat", it.toString()) }
                     parentId?.let { append("parentId", it) }
                     externalId?.let { append("externalId", it) }
+                }
+            )
+            when (response.status) {
+                HttpStatusCode.OK -> Either.Right((response.bodyAsText()))
+                else -> Either.Left(convertHttpError(response.status))
+            }
+        } catch (e: Throwable) {
+            Either.Left(ApiError(0, e.message ?: "Unknown exception"))
+        }
+    }
+
+    override suspend fun getsentinfo(paymentHash: String, id: String?): Either<ApiError, String> {
+        return try {
+            val response: HttpResponse = httpClient.submitForm(
+                url = "$apiHost/getsentinfo",
+                formParameters = Parameters.build {
+                    append("paymentHash", paymentHash)
+                    id?.let { append("id", it) }
+                }
+            )
+            when (response.status) {
+                HttpStatusCode.OK -> Either.Right((response.bodyAsText()))
+                else -> Either.Left(convertHttpError(response.status))
+            }
+        } catch (e: Throwable) {
+            Either.Left(ApiError(0, e.message ?: "Unknown exception"))
+        }
+    }
+
+    override suspend fun getreceivedinfo(paymentHash: String?, invoice: String?): Either<ApiError, String> {
+        return try {
+            val response: HttpResponse = httpClient.submitForm(
+                url = "$apiHost/getreceivedinfo",
+                formParameters = Parameters.build {
+                    paymentHash?.let { append("paymentHash", it) }
+                    invoice?.let { append("invoice", it) }
+                }
+            )
+            when (response.status) {
+                HttpStatusCode.OK -> Either.Right((response.bodyAsText()))
+                else -> Either.Left(convertHttpError(response.status))
+            }
+        } catch (e: Throwable) {
+            Either.Left(ApiError(0, e.message ?: "Unknown exception"))
+        }
+    }
+
+    override suspend fun listreceivedpayments(from: Int?, to: Int?, count: Int?, skip: Int?): Either<ApiError, String> {
+        return try {
+            val response: HttpResponse = httpClient.submitForm(
+                url = "$apiHost/listreceivedpayments",
+                formParameters = Parameters.build {
+                    from?.let { append("from", it.toString()) }
+                    to?.let { append("to", it.toString()) }
+                    count?.let { append("count", it.toString()) }
+                    skip?.let { append("skip", it.toString()) }
+                }
+            )
+            when (response.status) {
+                HttpStatusCode.OK -> Either.Right((response.bodyAsText()))
+                else -> Either.Left(convertHttpError(response.status))
+            }
+        } catch (e: Throwable) {
+            Either.Left(ApiError(0, e.message ?: "Unknown exception"))
+        }
+    }
+
+    override suspend fun getinvoice(paymentHash: String): Either<ApiError, String> {
+        return try {
+            val response: HttpResponse = httpClient.submitForm(
+                url = "$apiHost/getinvoice",
+                formParameters = Parameters.build {
+                    append("paymentHash", paymentHash)
+                }
+            )
+            when (response.status) {
+                HttpStatusCode.OK -> Either.Right((response.bodyAsText()))
+                else -> Either.Left(convertHttpError(response.status))
+            }
+        } catch (e: Throwable) {
+            Either.Left(ApiError(0, e.message ?: "Unknown exception"))
+        }
+    }
+
+    override suspend fun listinvoices(from: Int?, to: Int?, count: Int?, skip: Int?): Either<ApiError, String> {
+        return try {
+            val response: HttpResponse = httpClient.submitForm(
+                url = "$apiHost/listinvoices",
+                formParameters = Parameters.build {
+                    from?.let { append("from", it.toString()) }
+                    to?.let { append("to", it.toString()) }
+                    count?.let { append("count", it.toString()) }
+                    skip?.let { append("skip", it.toString()) }
+                }
+            )
+            when (response.status) {
+                HttpStatusCode.OK -> Either.Right((response.bodyAsText()))
+                else -> Either.Left(convertHttpError(response.status))
+            }
+        } catch (e: Throwable) {
+            Either.Left(ApiError(0, e.message ?: "Unknown exception"))
+        }
+    }
+
+    override suspend fun listpendinginvoices(from: Int?, to: Int?, count: Int?, skip: Int?): Either<ApiError, String> {
+        return try {
+            val response: HttpResponse = httpClient.submitForm(
+                url = "$apiHost/listpendinginvoices",
+                formParameters = Parameters.build {
+                    from?.let { append("from", it.toString()) }
+                    to?.let { append("to", it.toString()) }
+                    count?.let { append("count", it.toString()) }
+                    skip?.let { append("skip", it.toString()) }
                 }
             )
             when (response.status) {

--- a/src/nativeMain/kotlin/api/EclairClient.kt
+++ b/src/nativeMain/kotlin/api/EclairClient.kt
@@ -84,6 +84,15 @@ interface IEclairClient {
     suspend fun allchannels(): Either<ApiError, String>
 
     suspend fun allupdates(nodeId: String?): Either<ApiError, String>
+
+    suspend fun createinvoice(
+        description: String?,
+        descriptionHash: String?,
+        amountMsat: Int?,
+        expireIn: Int?,
+        fallbackAddress: String?,
+        paymentPreimage: String?,
+    ): Either<ApiError, String>
 }
 
 class EclairClient(private val apiHost: String, private val apiPassword: String) : IEclairClient {
@@ -392,6 +401,35 @@ class EclairClient(private val apiHost: String, private val apiPassword: String)
                 url = "$apiHost/allupdates",
                 formParameters = Parameters.build {
                     nodeId?.let { append("nodeId", it) }
+                }
+            )
+            when (response.status) {
+                HttpStatusCode.OK -> Either.Right((response.bodyAsText()))
+                else -> Either.Left(convertHttpError(response.status))
+            }
+        } catch (e: Throwable) {
+            Either.Left(ApiError(0, e.message ?: "Unknown exception"))
+        }
+    }
+
+    override suspend fun createinvoice(
+        description: String?,
+        descriptionHash: String?,
+        amountMsat: Int?,
+        expireIn: Int?,
+        fallbackAddress: String?,
+        paymentPreimage: String?
+    ): Either<ApiError, String> {
+        return try {
+            val response: HttpResponse = httpClient.submitForm(
+                url = "$apiHost/createinvoice",
+                formParameters = Parameters.build {
+                    description?.let { append("description", it) }
+                    descriptionHash?.let { append("descriptionHash", it) }
+                    amountMsat?.let { append("amountMsat", it.toString()) }
+                    expireIn?.let { append("expireIn", it.toString()) }
+                    fallbackAddress?.let { append("fallbackAddress", it) }
+                    paymentPreimage?.let { append("paymentPreimage", it) }
                 }
             )
             when (response.status) {

--- a/src/nativeMain/kotlin/api/EclairClient.kt
+++ b/src/nativeMain/kotlin/api/EclairClient.kt
@@ -538,7 +538,7 @@ class EclairClient(private val apiHost: String, private val apiPassword: String)
                 }
             )
             when (response.status) {
-                HttpStatusCode.OK -> Either.Right(Json.decodeFromString(response.bodyAsText()))
+                HttpStatusCode.OK -> Either.Right(response.bodyAsText())
                 else -> Either.Left(convertHttpError(response.status))
             }
         } catch (e: Throwable) {

--- a/src/nativeMain/kotlin/commands/CreateInvoice.kt
+++ b/src/nativeMain/kotlin/commands/CreateInvoice.kt
@@ -1,0 +1,57 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import arrow.core.flatMap
+import kotlinx.cli.ArgType
+import kotlinx.coroutines.runBlocking
+import types.CreateInvoiceResponse
+import types.Serialization
+
+class CreateInvoiceCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "createinvoice",
+    "Create a BOLT11 payment invoice."
+) {
+    private val description by option(
+        ArgType.String,
+        description = "A description for the invoice"
+    )
+    private val descriptionHash by option(
+        ArgType.String,
+        description = "Hash of the description for the invoice"
+    )
+    private val amountMsat by option(
+        ArgType.Int,
+        description = "Amount in millisatoshi for this invoice"
+    )
+    private val expireIn by option(
+        ArgType.Int,
+        description = "Number of seconds that the invoice will be valid"
+    )
+    private val fallbackAddress by option(
+        ArgType.String,
+        description = "An on-chain fallback address to receive the payment"
+    )
+    private val paymentPreimage by option(
+        ArgType.String,
+        description = "A user defined input for the generation of the paymentHash"
+    )
+
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val result = eclairClient.createinvoice(
+            description = description,
+            descriptionHash = descriptionHash,
+            amountMsat = amountMsat,
+            expireIn = expireIn,
+            fallbackAddress = fallbackAddress,
+            paymentPreimage = paymentPreimage
+        )
+            .flatMap { apiResponse -> Serialization.decode<CreateInvoiceResponse>(apiResponse) }
+            .map { decoded -> Serialization.encode(decoded) }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/commands/CreateInvoice.kt
+++ b/src/nativeMain/kotlin/commands/CreateInvoice.kt
@@ -5,7 +5,7 @@ import api.IEclairClientBuilder
 import arrow.core.flatMap
 import kotlinx.cli.ArgType
 import kotlinx.coroutines.runBlocking
-import types.CreateInvoiceResponse
+import types.Invoice
 import types.Serialization
 
 class CreateInvoiceCommand(
@@ -50,7 +50,7 @@ class CreateInvoiceCommand(
             fallbackAddress = fallbackAddress,
             paymentPreimage = paymentPreimage
         )
-            .flatMap { apiResponse -> Serialization.decode<CreateInvoiceResponse>(apiResponse) }
+            .flatMap { apiResponse -> Serialization.decode<Invoice>(apiResponse) }
             .map { decoded -> Serialization.encode(decoded) }
         resultWriter.write(result)
     }

--- a/src/nativeMain/kotlin/commands/DeleteInvoice.kt
+++ b/src/nativeMain/kotlin/commands/DeleteInvoice.kt
@@ -1,0 +1,34 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgType
+import kotlinx.coroutines.runBlocking
+import types.DeleteInvoiceResult
+import types.Serialization
+
+class DeleteInvoiceCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "deleteinvoice",
+    "Delete an unpaid BOLT11 payment invoice."
+) {
+    private val paymentHash by option(
+        ArgType.String,
+        description = "The payment hash of the invoice"
+    )
+
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val result = eclairClient.deleteinvoice(paymentHash!!).map { response ->
+            val result = if (response.contains("deleted invoice")) {
+                DeleteInvoiceResult(true, response)
+            } else {
+                DeleteInvoiceResult(false, response)
+            }
+            Serialization.encode(result)
+        }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/commands/GetInvoice.kt
+++ b/src/nativeMain/kotlin/commands/GetInvoice.kt
@@ -1,0 +1,31 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import arrow.core.flatMap
+import kotlinx.cli.ArgType
+import kotlinx.coroutines.runBlocking
+import types.Invoice
+import types.Serialization
+
+class GetInvoiceCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "getinvoice",
+    "Queries the payment DB for a stored invoice with the given paymentHash. If none is found, it responds HTTP 404."
+) {
+    private val paymentHash by option(
+        ArgType.String,
+        description = "The payment hash of the invoice you want to retrieve"
+    )
+
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val result = eclairClient.getinvoice(
+            paymentHash = paymentHash!!,
+        ).flatMap { apiResponse -> Serialization.decode<Invoice>(apiResponse) }
+            .map { decoded -> Serialization.encode(decoded) }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/commands/GetReceivedInfo.kt
+++ b/src/nativeMain/kotlin/commands/GetReceivedInfo.kt
@@ -1,0 +1,37 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import arrow.core.flatMap
+import kotlinx.cli.ArgType
+import kotlinx.coroutines.runBlocking
+import types.ReceivedInfoResponse
+import types.Serialization
+
+class GetReceivedInfoCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "getreceivedinfo",
+    "Checks whether a payment corresponding to the given paymentHash has been received. It is possible to use a BOLT11 invoice as parameter instead of the paymentHash but at least one of the two must be specified."
+) {
+    private val paymentHash by option(
+        ArgType.String,
+        description = "The payment hash you want to check."
+    )
+    private val invoice by option(
+        ArgType.String,
+        description = "The invoice containing the payment hash."
+    )
+
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val result = eclairClient.getreceivedinfo(
+            paymentHash = paymentHash,
+            invoice = invoice
+        )
+            .flatMap { apiResponse -> Serialization.decode<ReceivedInfoResponse>(apiResponse) }
+            .map { decoded -> Serialization.encode(decoded) }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/commands/GetSentInfo.kt
+++ b/src/nativeMain/kotlin/commands/GetSentInfo.kt
@@ -1,0 +1,53 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import arrow.core.Either
+import arrow.core.flatMap
+import kotlinx.cli.ArgType
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import types.ApiError
+import types.SentInfoResponse
+
+class GetSentInfoCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "getsentinfo",
+    "Returns a list of attempts to send an outgoing payment."
+) {
+    private val paymentHash by option(
+        ArgType.String,
+        description = "The payment hash common to all payment attempts to be retrieved"
+    )
+    private val id by option(
+        ArgType.String,
+        description = "The unique id of the payment attempt"
+    )
+
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        val result = eclairClient.getsentinfo(
+            paymentHash = paymentHash!!,
+            id = id
+        )
+            .flatMap { apiResponse ->
+                try {
+                    Either.Right(format.decodeFromString<List<SentInfoResponse>>(apiResponse))
+                } catch (e: Throwable) {
+                    Either.Left(ApiError(1, "api response could not be parsed: $apiResponse"))
+                }
+            }
+            .map { decoded ->
+                format.encodeToString(decoded)
+            }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/commands/ListInvoices.kt
+++ b/src/nativeMain/kotlin/commands/ListInvoices.kt
@@ -1,0 +1,63 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import arrow.core.Either
+import arrow.core.flatMap
+import kotlinx.cli.ArgType
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import types.ApiError
+import types.Invoice
+
+class ListInvoicesCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "listinvoices",
+    "Returns all the BOLT 11 invoices stored."
+) {
+    private val from by option(
+        ArgType.Int,
+        description = "Filters elements no older than this unix-timestamp"
+    )
+    private val to by option(
+        ArgType.Int,
+        description = "Filters elements no younger than this unix-timestamp"
+    )
+    private val count by option(
+        ArgType.Int,
+        description = "Limits the number of results returned"
+    )
+    private val skip by option(
+        ArgType.Int,
+        description = "Skip some number of results"
+    )
+
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        val result = eclairClient.listinvoices(
+            from,
+            to,
+            count,
+            skip
+        )
+            .flatMap { apiResponse ->
+                try {
+                    Either.Right(format.decodeFromString<List<Invoice>>(apiResponse))
+                } catch (e: Throwable) {
+                    Either.Left(ApiError(1, "api response could not be parsed: $apiResponse"))
+                }
+            }
+            .map { decoded ->
+                format.encodeToString(decoded)
+            }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/commands/ListPendingInvoices.kt
+++ b/src/nativeMain/kotlin/commands/ListPendingInvoices.kt
@@ -1,0 +1,63 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import arrow.core.Either
+import arrow.core.flatMap
+import kotlinx.cli.ArgType
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import types.ApiError
+import types.Invoice
+
+class ListPendingInvoicesCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "listpendinginvoices",
+    "Returns all non-paid, non-expired BOLT11 invoices stored. The invoices can be filtered by date and are output in descending order."
+) {
+    private val from by option(
+        ArgType.Int,
+        description = "Filters elements no older than this unix-timestamp"
+    )
+    private val to by option(
+        ArgType.Int,
+        description = "Filters elements no younger than this unix-timestamp"
+    )
+    private val count by option(
+        ArgType.Int,
+        description = "Limits the number of results returned"
+    )
+    private val skip by option(
+        ArgType.Int,
+        description = "Skip some number of results"
+    )
+
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        val result = eclairClient.listpendinginvoices(
+            from = from,
+            to = to,
+            count = count,
+            skip = skip
+        )
+            .flatMap { apiResponse ->
+                try {
+                    Either.Right(format.decodeFromString<List<Invoice>>(apiResponse))
+                } catch (e: Throwable) {
+                    Either.Left(ApiError(1, "api response could not be parsed: $apiResponse"))
+                }
+            }
+            .map { decoded ->
+                format.encodeToString(decoded)
+            }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/commands/ListReceivedPayments.kt
+++ b/src/nativeMain/kotlin/commands/ListReceivedPayments.kt
@@ -1,0 +1,63 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import arrow.core.Either
+import arrow.core.flatMap
+import kotlinx.cli.ArgType
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import types.ApiError
+import types.ReceivedInfoResponse
+
+class ListReceivedPaymentsCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "listreceivedpayments",
+    "Returns the list of payments received by your node."
+) {
+    private val from by option(
+        ArgType.Int,
+        description = "Filters elements no older than this unix-timestamp"
+    )
+    private val to by option(
+        ArgType.Int,
+        description = "Filters elements no younger than this unix-timestamp"
+    )
+    private val count by option(
+        ArgType.Int,
+        description = "Limits the number of results returned"
+    )
+    private val skip by option(
+        ArgType.Int,
+        description = "Skip some number of results"
+    )
+
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        val result = eclairClient.listreceivedpayments(
+            from = from,
+            to = to,
+            count = count,
+            skip = skip
+        )
+            .flatMap { apiResponse ->
+                try {
+                    Either.Right(format.decodeFromString<List<ReceivedInfoResponse>>(apiResponse))
+                } catch (e: Throwable) {
+                    Either.Left(ApiError(1, "api response could not be parsed: $apiResponse"))
+                }
+            }
+            .map { decoded ->
+                format.encodeToString(decoded)
+            }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/commands/ParseInvoice.kt
+++ b/src/nativeMain/kotlin/commands/ParseInvoice.kt
@@ -1,0 +1,32 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import arrow.core.flatMap
+import kotlinx.cli.ArgType
+import kotlinx.coroutines.runBlocking
+import types.Invoice
+import types.Serialization
+
+class ParseInvoiceCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "parseinvoice",
+    "Returns detailed information about the given invoice."
+) {
+    private val invoice by option(
+        ArgType.String,
+        description = "The invoice you want to decode"
+    )
+
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val result = eclairClient.parseinvoice(
+            invoice = invoice!!,
+        )
+            .flatMap { apiResponse -> Serialization.decode<Invoice>(apiResponse) }
+            .map { decoded -> Serialization.encode(decoded) }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/commands/PayInvoice.kt
+++ b/src/nativeMain/kotlin/commands/PayInvoice.kt
@@ -1,0 +1,73 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgType
+import kotlinx.coroutines.runBlocking
+import types.InvoiceResult
+import types.Serialization
+
+class PayInvoiceCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "payinvoice",
+    "Pays a BOLT11 invoice. In case of failure, the payment will be retried up to maxAttempts times."
+) {
+    private val invoice by option(
+        ArgType.String,
+        description = "The invoice you want to pay"
+    )
+    private val amountMsat by option(
+        ArgType.Int,
+        description = "Amount to pay if the invoice does not have one"
+    )
+    private val maxAttempts by option(
+        ArgType.Int,
+        description = "Max number of retries"
+    )
+    private val maxFeeFlatSat by option(
+        ArgType.Int,
+        description = "Fee threshold to be paid along the payment route"
+    )
+    private val maxFeePct by option(
+        ArgType.Int,
+        description = "Max percentage to be paid in fees along the payment route (ignored if below maxFeeFlatSat)"
+    )
+    private val externalId by option(
+        ArgType.String,
+        description = "Extra payment identifier specified by the caller"
+    )
+    private val pathFindingExperimentName by option(
+        ArgType.String,
+        description = "Name of the path-finding configuration that should be used"
+    )
+    private val blocking by option(
+        ArgType.Boolean,
+        description = "Block until the payment completes"
+    )
+
+
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+
+        val result = eclairClient.payinvoice(
+            invoice!!,
+            amountMsat,
+            maxAttempts,
+            maxFeeFlatSat,
+            maxFeePct,
+            externalId,
+            pathFindingExperimentName,
+            blocking
+        ).map { response ->
+            val result = if (response.length == 36) {
+                InvoiceResult(true, response)
+            } else {
+                InvoiceResult(false, response)
+            }
+            Serialization.encode(result)
+        }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/commands/SendToNode.kt
+++ b/src/nativeMain/kotlin/commands/SendToNode.kt
@@ -2,8 +2,12 @@ package commands
 
 import IResultWriter
 import api.IEclairClientBuilder
+import arrow.core.Either
 import kotlinx.cli.ArgType
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import types.ApiError
 import types.InvoiceResult
 import types.Serialization
 
@@ -45,7 +49,12 @@ class SendToNodeCommand(
 
     override fun execute() = runBlocking {
         val eclairClient = eclairClientBuilder.build(host, password)
-        val result = eclairClient.sendtonode(
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        val response = eclairClient.sendtonode(
             nodeId!!,
             amountMsat!!,
             maxAttempts,
@@ -53,13 +62,17 @@ class SendToNodeCommand(
             maxFeePct,
             externalId,
             pathFindingExperimentName,
-        ).map { response ->
-            val result = if (response.length == 36) {
-                InvoiceResult(true, response)
-            } else {
-                InvoiceResult(false, response)
+        )
+        val result: Either<ApiError, String> = when (response) {
+            is Either.Left -> Either.Left(response.value)
+            is Either.Right -> {
+                try {
+                    val decoded = format.decodeFromString<String>(response.value)
+                    Either.Right(Serialization.encode(InvoiceResult(true, decoded)))
+                } catch (e: SerializationException) {
+                    Either.Left(ApiError(1, "API response could not be parsed: ${response.value}"))
+                }
             }
-            Serialization.encode(result)
         }
         resultWriter.write(result)
     }

--- a/src/nativeMain/kotlin/commands/SendToNode.kt
+++ b/src/nativeMain/kotlin/commands/SendToNode.kt
@@ -1,0 +1,66 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgType
+import kotlinx.coroutines.runBlocking
+import types.InvoiceResult
+import types.Serialization
+
+class SendToNodeCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "sendtonode",
+    "Sends money to a node using keysend (spontaneous payment without a Bolt11 invoice) as specified in blip 3. "
+) {
+    private val nodeId by option(
+        ArgType.String,
+        description = "The recipient of this payment"
+    )
+    private val amountMsat by option(
+        ArgType.Int,
+        description = "Amount to pay"
+    )
+    private val maxAttempts by option(
+        ArgType.Int,
+        description = "Max number of retries"
+    )
+    private val maxFeeFlatSat by option(
+        ArgType.Int,
+        description = "Fee threshold to be paid along the payment route"
+    )
+    private val maxFeePct by option(
+        ArgType.Int,
+        description = "Max percentage to be paid in fees along the payment route (ignored if below maxFeeFlatSat"
+    )
+    private val externalId by option(
+        ArgType.String,
+        description = "Extra payment identifier specified by the caller"
+    )
+    private val pathFindingExperimentName by option(
+        ArgType.String,
+        description = "Name of the path-finding configuration that should be used"
+    )
+
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val result = eclairClient.sendtonode(
+            nodeId!!,
+            amountMsat!!,
+            maxAttempts,
+            maxFeeFlatSat,
+            maxFeePct,
+            externalId,
+            pathFindingExperimentName,
+        ).map { response ->
+            val result = if (response.length == 36) {
+                InvoiceResult(true, response)
+            } else {
+                InvoiceResult(false, response)
+            }
+            Serialization.encode(result)
+        }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/commands/SendToRoute.kt
+++ b/src/nativeMain/kotlin/commands/SendToRoute.kt
@@ -1,0 +1,77 @@
+package commands
+
+import IResultWriter
+import api.IEclairClientBuilder
+import arrow.core.flatMap
+import kotlinx.cli.ArgType
+import kotlinx.coroutines.runBlocking
+import types.RouteResult
+import types.Serialization
+
+class SendToRouteCommand(
+    private val resultWriter: IResultWriter,
+    private val eclairClientBuilder: IEclairClientBuilder
+) : BaseCommand(
+    "sendtoroute",
+    "Sends money to a node forcing the payment to go through the given route."
+) {
+    private val invoice by option(
+        ArgType.String,
+        description = "The invoice you want to pay"
+    )
+    private val nodeIds by option(
+        ArgType.String,
+        description = "A list of nodeIds from source to destination of the payment"
+    )
+    private val shortChannelIds by option(
+        ArgType.String,
+        description = "A list of shortChannelIds from source to destination of the payment"
+    )
+    private val amountMsat by option(
+        ArgType.Int,
+        description = "Amount to pay"
+    )
+    private val paymentHash by option(
+        ArgType.String,
+        description = "The payment hash for this payment"
+    )
+    private val finalCltvExpiry by option(
+        ArgType.Int,
+        description = "The total CLTV expiry value for this payment"
+    )
+    private val maxFeeMsat by option(
+        ArgType.Int,
+        description = "Maximum fee allowed for this payment"
+    )
+    private val recipientAmountMsat by option(
+        ArgType.Int,
+        description = "Total amount that the recipient should receive (if using MPP)"
+    )
+    private val parentId by option(
+        ArgType.String,
+        description = "Id of the whole payment (if using MPP)"
+    )
+    private val externalId by option(
+        ArgType.String,
+        description = "Extra payment identifier specified by the caller"
+    )
+
+    override fun execute() = runBlocking {
+        val eclairClient = eclairClientBuilder.build(host, password)
+        val result = eclairClient.sendtoroute(
+            invoice = invoice!!,
+            nodeIds = nodeIds?.split(","),
+            shortChannelIds = shortChannelIds?.split(","),
+            amountMsat = amountMsat!!,
+            paymentHash = paymentHash!!,
+            finalCltvExpiry = finalCltvExpiry!!,
+            maxFeeMsat = maxFeeMsat,
+            recipientAmountMsat = recipientAmountMsat,
+            parentId = parentId,
+            externalId = externalId,
+        )
+            .flatMap { apiResponse -> Serialization.decode<RouteResult>(apiResponse) }
+            .map { decoded -> Serialization.encode(decoded) }
+        resultWriter.write(result)
+    }
+}

--- a/src/nativeMain/kotlin/types/EclairApiTypes.kt
+++ b/src/nativeMain/kotlin/types/EclairApiTypes.kt
@@ -109,3 +109,6 @@ data class Invoice(
 
 @Serializable
 data class DeleteInvoiceResult(val success: Boolean, val message: String) : EclairApiType()
+
+@Serializable
+data class InvoiceResult(val success: Boolean, val message: String) : EclairApiType()

--- a/src/nativeMain/kotlin/types/EclairApiTypes.kt
+++ b/src/nativeMain/kotlin/types/EclairApiTypes.kt
@@ -102,7 +102,7 @@ data class Invoice(
     val paymentMetadata: String,
     val expiry: Int,
     val minFinalCltvExpiry: Int,
-    val amount: Long,
+    val amount: Long? = null,
     val features: Features,
     val routingInfo: List<@Contextual Any>
 ) : EclairApiType()

--- a/src/nativeMain/kotlin/types/EclairApiTypes.kt
+++ b/src/nativeMain/kotlin/types/EclairApiTypes.kt
@@ -92,7 +92,7 @@ data class ChannelFlags(
 )
 
 @Serializable
-data class CreateInvoiceResponse(
+data class Invoice(
     val prefix: String,
     val timestamp: Long,
     val nodeId: String,

--- a/src/nativeMain/kotlin/types/EclairApiTypes.kt
+++ b/src/nativeMain/kotlin/types/EclairApiTypes.kt
@@ -112,3 +112,9 @@ data class DeleteInvoiceResult(val success: Boolean, val message: String) : Ecla
 
 @Serializable
 data class InvoiceResult(val success: Boolean, val message: String) : EclairApiType()
+
+@Serializable
+data class RouteResult(
+    val paymentId: String,
+    val parentId: String
+) : EclairApiType()

--- a/src/nativeMain/kotlin/types/EclairApiTypes.kt
+++ b/src/nativeMain/kotlin/types/EclairApiTypes.kt
@@ -106,3 +106,6 @@ data class CreateInvoiceResponse(
     val features: Features,
     val routingInfo: List<@Contextual Any>
 ) : EclairApiType()
+
+@Serializable
+data class DeleteInvoiceResult(val success: Boolean, val message: String) : EclairApiType()

--- a/src/nativeMain/kotlin/types/EclairApiTypes.kt
+++ b/src/nativeMain/kotlin/types/EclairApiTypes.kt
@@ -90,3 +90,19 @@ data class ChannelFlags(
     val isEnabled: Boolean,
     val isNode1: Boolean
 )
+
+@Serializable
+data class CreateInvoiceResponse(
+    val prefix: String,
+    val timestamp: Long,
+    val nodeId: String,
+    val serialized: String,
+    val description: String,
+    val paymentHash: String,
+    val paymentMetadata: String,
+    val expiry: Int,
+    val minFinalCltvExpiry: Int,
+    val amount: Long,
+    val features: Features,
+    val routingInfo: List<@Contextual Any>
+) : EclairApiType()

--- a/src/nativeMain/kotlin/types/EclairApiTypes.kt
+++ b/src/nativeMain/kotlin/types/EclairApiTypes.kt
@@ -118,3 +118,49 @@ data class RouteResult(
     val paymentId: String,
     val parentId: String
 ) : EclairApiType()
+
+@Serializable
+data class SentInfoResponse(
+    val id: String,
+    val parentId: String,
+    val paymentHash: String,
+    val paymentType: String,
+    val amount: Long,
+    val recipientAmount: Long,
+    val recipientNodeId: String,
+    val createdAt: Timestamp,
+    val invoice: Invoice,
+    val status: PaymentStatus
+)
+
+@Serializable
+data class PaymentStatus(
+    val type: String,
+    val paymentPreimage: String,
+    val feesPaid: Long,
+    val route: List<Route>,
+    val completedAt: Timestamp
+)
+
+@Serializable
+data class Route(
+    val nodeId: String,
+    val nextNodeId: String,
+    val shortChannelId: String
+)
+
+@Serializable
+data class ReceivedInfoResponse(
+    val invoice: Invoice,
+    val paymentPreimage: String,
+    val paymentType: String,
+    val createdAt: Timestamp,
+    val status: ReceivePaymentStatus
+) : EclairApiType()
+
+@Serializable
+data class ReceivePaymentStatus(
+    val type: String,
+    val amount: Long? = null,
+    val receivedAt: Timestamp? = null
+)

--- a/src/nativeTest/kotlin/commands/CreateInvoiceTest.kt
+++ b/src/nativeTest/kotlin/commands/CreateInvoiceTest.kt
@@ -1,0 +1,63 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import kotlinx.serialization.json.Json
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import types.CreateInvoiceResponse
+import kotlin.test.*
+
+class CreateInvoiceCommandTest {
+    @OptIn(ExperimentalCli::class)
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = CreateInvoiceCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(
+            arrayOf(
+                "createinvoice",
+                "-p",
+                "password",
+                "--description",
+                "BroWantsCoffee",
+                "--amountMsat",
+                "1000"
+            )
+        )
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter =
+            runTest(DummyEclairClient(createInvoiceResponse = DummyEclairClient.validCreateInvoiceResponse))
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        val format = Json { ignoreUnknownKeys = true }
+        assertEquals(
+            format.decodeFromString(CreateInvoiceResponse.serializer(), DummyEclairClient.validCreateInvoiceResponse),
+            format.decodeFromString(CreateInvoiceResponse.serializer(), resultWriter.lastResult!!),
+        )
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+
+    @Test
+    fun `serialization error`() {
+        val resultWriter = runTest(DummyEclairClient(createInvoiceResponse = "{invalidJson}"))
+        assertNull(resultWriter.lastResult)
+        assertNotNull(resultWriter.lastError)
+        assertTrue(resultWriter.lastError!!.message.contains("api response could not be parsed"))
+    }
+}

--- a/src/nativeTest/kotlin/commands/DeleteInvoiceTest.kt
+++ b/src/nativeTest/kotlin/commands/DeleteInvoiceTest.kt
@@ -1,0 +1,53 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import types.DeleteInvoiceResult
+import types.Serialization
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCli::class)
+class DeleteInvoiceCommandTest {
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = DeleteInvoiceCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(
+            arrayOf(
+                "deleteinvoice",
+                "-p",
+                "password",
+                "--paymentHash",
+                "304a26dd35e8760a677b9250751855d6a982e8ce14c0ff5a5b27391d19e5093a"
+            )
+        )
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter = runTest(DummyEclairClient())
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        val expectedOutput =
+            Serialization.encode(DeleteInvoiceResult(true, DummyEclairClient.validDeleteInvoiceResponse))
+        assertEquals(expectedOutput, resultWriter.lastResult)
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+}

--- a/src/nativeTest/kotlin/commands/GetInvoiceTest.kt
+++ b/src/nativeTest/kotlin/commands/GetInvoiceTest.kt
@@ -1,0 +1,60 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import kotlinx.serialization.json.Json
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import types.Invoice
+import kotlin.test.*
+
+class GetInvoiceCommandTest {
+    @OptIn(ExperimentalCli::class)
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = GetInvoiceCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(
+            arrayOf(
+                "getinvoice",
+                "-p",
+                "password",
+                "--paymentHash",
+                "a482c4d3a232d028881aee9ccd27c5f7b554824138c927baf40b8d84d38d72ce"
+            )
+        )
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter = runTest(DummyEclairClient(getinvoiceResponse = DummyEclairClient.validGetInvoiceResponse))
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        val format = Json { ignoreUnknownKeys = true }
+        assertEquals(
+            format.decodeFromString(Invoice.serializer(), DummyEclairClient.validGetInvoiceResponse),
+            format.decodeFromString(Invoice.serializer(), resultWriter.lastResult!!),
+        )
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+
+    @Test
+    fun `serialization error`() {
+        val resultWriter = runTest(DummyEclairClient(getinvoiceResponse = "{invalidJson}"))
+        assertNull(resultWriter.lastResult)
+        assertNotNull(resultWriter.lastError)
+        assertTrue(resultWriter.lastError!!.message.contains("api response could not be parsed"))
+    }
+}

--- a/src/nativeTest/kotlin/commands/GetReceivedInfoTest.kt
+++ b/src/nativeTest/kotlin/commands/GetReceivedInfoTest.kt
@@ -1,0 +1,61 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import kotlinx.serialization.json.Json
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import types.ReceivedInfoResponse
+import kotlin.test.*
+
+class GetReceivedInfoCommandTest {
+    @OptIn(ExperimentalCli::class)
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = GetReceivedInfoCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(
+            arrayOf(
+                "getreceivedinfo",
+                "-p",
+                "password",
+                "--paymentHash",
+                "a482c4d3a232d028881aee9ccd27c5f7b554824138c927baf40b8d84d38d72ce"
+            )
+        )
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter =
+            runTest(DummyEclairClient(getreceivedinfoResponse = DummyEclairClient.validGetReceivedInfoResponse))
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        val format = Json { ignoreUnknownKeys = true }
+        assertEquals(
+            format.decodeFromString(ReceivedInfoResponse.serializer(), DummyEclairClient.validGetReceivedInfoResponse),
+            format.decodeFromString(ReceivedInfoResponse.serializer(), resultWriter.lastResult!!),
+        )
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+
+    @Test
+    fun `serialization error`() {
+        val resultWriter = runTest(DummyEclairClient(getreceivedinfoResponse = "{invalidJson}"))
+        assertNull(resultWriter.lastResult)
+        assertNotNull(resultWriter.lastError)
+        assertTrue(resultWriter.lastError!!.message.contains("api response could not be parsed"))
+    }
+}

--- a/src/nativeTest/kotlin/commands/GetSentInfoTest.kt
+++ b/src/nativeTest/kotlin/commands/GetSentInfoTest.kt
@@ -1,0 +1,63 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import kotlinx.serialization.json.Json
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import kotlin.test.*
+
+class GetSentInfoCommandTest {
+    @OptIn(ExperimentalCli::class)
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = GetSentInfoCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(
+            arrayOf(
+                "getsentinfo",
+                "-p",
+                "password",
+                "--paymentHash",
+                "a482c4d3a232d028881aee9ccd27c5f7b554824138c927baf40b8d84d38d72ce,03c5b161c16e9f8ef3f3bccfb74a6e9a3b423dd41fe2848174b7209f1c2ea25dad"
+            )
+        )
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter = runTest(DummyEclairClient(getsentinfoResponse = DummyEclairClient.validGetSentInfoResponse))
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        assertEquals(
+            format.parseToJsonElement(DummyEclairClient.validGetSentInfoResponse),
+            format.decodeFromString(resultWriter.lastResult!!),
+        )
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+
+    @Test
+    fun `serialization error`() {
+        val resultWriter = runTest(DummyEclairClient(getsentinfoResponse = "{invalidJson}"))
+        assertNull(resultWriter.lastResult)
+        assertNotNull(resultWriter.lastError)
+        assertTrue(resultWriter.lastError!!.message.contains("api response could not be parsed"))
+    }
+}

--- a/src/nativeTest/kotlin/commands/ListInvoicesTest.kt
+++ b/src/nativeTest/kotlin/commands/ListInvoicesTest.kt
@@ -1,0 +1,56 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import kotlinx.serialization.json.Json
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import kotlin.test.*
+
+class ListInvoicesCommandTest {
+    @OptIn(ExperimentalCli::class)
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = ListInvoicesCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(arrayOf("listinvoices", "-p", "password"))
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter =
+            runTest(DummyEclairClient(listinvoicesResponse = DummyEclairClient.validListInvoicesResponse))
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        assertEquals(
+            format.parseToJsonElement(DummyEclairClient.validListInvoicesResponse),
+            format.decodeFromString(resultWriter.lastResult!!),
+        )
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+
+    @Test
+    fun `serialization error`() {
+        val resultWriter = runTest(DummyEclairClient(listinvoicesResponse = "{invalidJson}"))
+        assertNull(resultWriter.lastResult)
+        assertNotNull(resultWriter.lastError)
+        assertTrue(resultWriter.lastError!!.message.contains("api response could not be parsed"))
+    }
+}

--- a/src/nativeTest/kotlin/commands/ListPendingInvoicesTest.kt
+++ b/src/nativeTest/kotlin/commands/ListPendingInvoicesTest.kt
@@ -1,0 +1,56 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import kotlinx.serialization.json.Json
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import kotlin.test.*
+
+class ListPendingInvoicesCommandTest {
+    @OptIn(ExperimentalCli::class)
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = ListPendingInvoicesCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(arrayOf("listpendinginvoices", "-p", "password"))
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter =
+            runTest(DummyEclairClient(listpendinginvoicesResponse = DummyEclairClient.validListPendingInvoicesResponse))
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        assertEquals(
+            format.parseToJsonElement(DummyEclairClient.validListPendingInvoicesResponse),
+            format.decodeFromString(resultWriter.lastResult!!),
+        )
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+
+    @Test
+    fun `serialization error`() {
+        val resultWriter = runTest(DummyEclairClient(listpendinginvoicesResponse = "{invalidJson}"))
+        assertNull(resultWriter.lastResult)
+        assertNotNull(resultWriter.lastError)
+        assertTrue(resultWriter.lastError!!.message.contains("api response could not be parsed"))
+    }
+}

--- a/src/nativeTest/kotlin/commands/ListReceivedPaymentsTest.kt
+++ b/src/nativeTest/kotlin/commands/ListReceivedPaymentsTest.kt
@@ -1,0 +1,56 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import kotlinx.serialization.json.Json
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import kotlin.test.*
+
+class ListReceivedPaymentsCommandTest {
+    @OptIn(ExperimentalCli::class)
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = ListReceivedPaymentsCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(arrayOf("listreceivedpayments", "-p", "password"))
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter =
+            runTest(DummyEclairClient(listreceivedpaymentsResponse = DummyEclairClient.validListReceivedPaymentsResponse))
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        val format = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+            isLenient = true
+        }
+        assertEquals(
+            format.parseToJsonElement(DummyEclairClient.validListReceivedPaymentsResponse),
+            format.decodeFromString(resultWriter.lastResult!!),
+        )
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+
+    @Test
+    fun `serialization error`() {
+        val resultWriter = runTest(DummyEclairClient(listreceivedpaymentsResponse = "{invalidJson}"))
+        assertNull(resultWriter.lastResult)
+        assertNotNull(resultWriter.lastError)
+        assertTrue(resultWriter.lastError!!.message.contains("api response could not be parsed"))
+    }
+}

--- a/src/nativeTest/kotlin/commands/ParseInvoiceTest.kt
+++ b/src/nativeTest/kotlin/commands/ParseInvoiceTest.kt
@@ -11,22 +11,20 @@ import types.ApiError
 import types.Invoice
 import kotlin.test.*
 
-class CreateInvoiceCommandTest {
+class ParseInvoiceCommandTest {
     @OptIn(ExperimentalCli::class)
     private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
         val resultWriter = DummyResultWriter()
-        val command = CreateInvoiceCommand(resultWriter, eclairClient)
+        val command = ParseInvoiceCommand(resultWriter, eclairClient)
         val parser = ArgParser("test")
         parser.subcommands(command)
         parser.parse(
             arrayOf(
-                "createinvoice",
+                "parseinvoice",
                 "-p",
                 "password",
-                "--description",
-                "BroWantsCoffee",
-                "--amountMsat",
-                "1000"
+                "--invoice",
+                "lnbcrt10n1pjd4rpdpp5mj9vgxxw7cr39cyk8czcycswavhyx5xhg2tgtulp82wtkx9vg90qdqhgfex74mpde68xsm0venx2egsp5ph8nceurv5sp5528f2cqucpk2z8vf024n3r7446tfqw67flstj5smqz9gxqrrsscqp79q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgqq4g0l9xms94tskmm7hkzarpdrdfgwjmgs2rzg3xc904vtqju08a9536hhn5224733a55htd4r3wa8e3fcj483zx2vq342j4wru9pwjsqrkyqpw"
             )
         )
         return resultWriter
@@ -35,12 +33,12 @@ class CreateInvoiceCommandTest {
     @Test
     fun `successful request`() {
         val resultWriter =
-            runTest(DummyEclairClient(createInvoiceResponse = DummyEclairClient.validCreateInvoiceResponse))
+            runTest(DummyEclairClient(parseInvoiceResponse = DummyEclairClient.validParseInvoiceResponse))
         assertNull(resultWriter.lastError)
         assertNotNull(resultWriter.lastResult)
         val format = Json { ignoreUnknownKeys = true }
         assertEquals(
-            format.decodeFromString(Invoice.serializer(), DummyEclairClient.validCreateInvoiceResponse),
+            format.decodeFromString(Invoice.serializer(), DummyEclairClient.validParseInvoiceResponse),
             format.decodeFromString(Invoice.serializer(), resultWriter.lastResult!!),
         )
     }
@@ -55,7 +53,7 @@ class CreateInvoiceCommandTest {
 
     @Test
     fun `serialization error`() {
-        val resultWriter = runTest(DummyEclairClient(createInvoiceResponse = "{invalidJson}"))
+        val resultWriter = runTest(DummyEclairClient(parseInvoiceResponse = "{invalidJson}"))
         assertNull(resultWriter.lastResult)
         assertNotNull(resultWriter.lastError)
         assertTrue(resultWriter.lastError!!.message.contains("api response could not be parsed"))

--- a/src/nativeTest/kotlin/commands/PayInvoiceTest.kt
+++ b/src/nativeTest/kotlin/commands/PayInvoiceTest.kt
@@ -1,0 +1,53 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import types.InvoiceResult
+import types.Serialization
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCli::class)
+class PayInvoiceCommandTest {
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = PayInvoiceCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(
+            arrayOf(
+                "payinvoice",
+                "-p",
+                "password",
+                "--invoice",
+                "lnbcrt9990p1pjd4wz0pp5j4vn0usn95n2rapus3ltxytr6sum5lrah2hq6yhphsxnaujz9m3qdq5f9nx2etv2dkx2ets09ussp58wudf374k2ntpyel7kmhnfyklnfrfep977ax75z9g50rnsfa2hpsmqz9gxqrrsscqp79q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgq79wmpuhf20ha3z6f55sg0dje7k62w8vyn84zne5k9v8lm2vf6k2q792v7kgf4ch7rs2an3q33yks2gyfavdl7pejhqklr48mwar8l2cpnzek3g"
+            )
+        )
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter = runTest(DummyEclairClient())
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        val expectedOutput =
+            Serialization.encode(InvoiceResult(true, DummyEclairClient.validPayInvoiceResponse))
+        assertEquals(expectedOutput, resultWriter.lastResult)
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+}

--- a/src/nativeTest/kotlin/commands/SendToNodeTest.kt
+++ b/src/nativeTest/kotlin/commands/SendToNodeTest.kt
@@ -1,0 +1,55 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.ApiError
+import types.InvoiceResult
+import types.Serialization
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCli::class)
+class SendToNodeCommandTest {
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = SendToNodeCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(
+            arrayOf(
+                "sendtonode",
+                "-p",
+                "password",
+                "--nodeId",
+                "02f666711319435b7905dd77d10c269d8d50c02668b975f526577167d370b50a3e",
+                "--amountMsat",
+                "1000",
+            )
+        )
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter = runTest(DummyEclairClient())
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        val expectedOutput =
+            Serialization.encode(InvoiceResult(true, DummyEclairClient.validSendToNodeResponse))
+        assertEquals(expectedOutput, resultWriter.lastResult)
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+}

--- a/src/nativeTest/kotlin/commands/SendToRouteTest.kt
+++ b/src/nativeTest/kotlin/commands/SendToRouteTest.kt
@@ -1,0 +1,67 @@
+package commands
+
+import api.IEclairClientBuilder
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ExperimentalCli
+import kotlinx.serialization.json.Json
+import mocks.DummyEclairClient
+import mocks.DummyResultWriter
+import mocks.FailingEclairClient
+import types.*
+import kotlin.test.*
+
+@OptIn(ExperimentalCli::class)
+class SendToRouteCommandTest {
+    private fun runTest(eclairClient: IEclairClientBuilder): DummyResultWriter {
+        val resultWriter = DummyResultWriter()
+        val command = SendToRouteCommand(resultWriter, eclairClient)
+        val parser = ArgParser("test")
+        parser.subcommands(command)
+        parser.parse(
+            arrayOf(
+                "sendtoroute",
+                "-p",
+                "password",
+                "--invoice",
+                "lnbcrt1pjdkk2fpp5keyzpk6c8les7hydfs38a3xaqy43mpum56lwrszugac905wxs6rqdq523jhxapq2pshjmt9de6qsp5nlxmqucnz797rvrx4sx7gk2z0y00wyy4zh2rs0tnsnfekzcchl0qmqz9gxqrrsscqp79q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgqckp6gsqa0s9vas592myu33a8m7tjrw2cjml9p2s5apwdchv5lcv5elq70j0lxxwmcpggnryara0yd3vd4e3zkrak3a3dj3z37zvmx8qpecw09x",
+                "--nodeIds",
+                "02fe677ac8cd61399d097535a3e8a51a0849e57cdbab9b34796c86f3e33568cbe2,028e2403fbfddb3d787843361f91adbda64c6f622921b19fb48f5766508bcadb29",
+                "--amountMsat",
+                "1000000",
+                "--paymentHash",
+                "b64820db583ff30f5c8d4c227ec4dd012b1d879ba6bee1c05c477057d1c68686",
+                "--finalCltvExpiry",
+                "144"
+            )
+        )
+        return resultWriter
+    }
+
+    @Test
+    fun `successful request`() {
+        val resultWriter = runTest(DummyEclairClient(sendToRouteResponse = DummyEclairClient.validSendToRouteResponse))
+        assertNull(resultWriter.lastError)
+        assertNotNull(resultWriter.lastResult)
+        val format = Json { ignoreUnknownKeys = true }
+        assertEquals(
+            format.decodeFromString(RouteResult.serializer(), DummyEclairClient.validSendToRouteResponse),
+            format.decodeFromString(RouteResult.serializer(), resultWriter.lastResult!!),
+        )
+    }
+
+    @Test
+    fun `api error`() {
+        val error = ApiError(42, "test failure message")
+        val resultWriter = runTest(FailingEclairClient(error))
+        assertNull(resultWriter.lastResult)
+        assertEquals(error, resultWriter.lastError)
+    }
+
+    @Test
+    fun `serialization error`() {
+        val resultWriter = runTest(DummyEclairClient(sendToRouteResponse = "{invalid json}"))
+        assertNull(resultWriter.lastResult)
+        assertNotNull(resultWriter.lastError)
+        assertTrue(resultWriter.lastError!!.message.contains("api response could not be parsed"))
+    }
+}

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -26,6 +26,7 @@ class DummyEclairClient(
     private val parseInvoiceResponse: String = validParseInvoiceResponse,
     private val payInvoiceResponse: String = validPayInvoiceResponse,
     private val sendToNodeResponse: String = validSendToNodeResponse,
+    private val sendToRouteResponse: String = validSendToRouteResponse,
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
@@ -118,6 +119,19 @@ class DummyEclairClient(
         externalId: String?,
         pathFindingExperimentName: String?
     ): Either<ApiError, String> = Either.Right(sendToNodeResponse)
+
+    override suspend fun sendtoroute(
+        invoice: String,
+        nodeIds: List<String>?,
+        shortChannelIds: List<String>?,
+        amountMsat: Int,
+        paymentHash: String,
+        finalCltvExpiry: Int,
+        maxFeeMsat: Int?,
+        recipientAmountMsat: Int?,
+        parentId: String?,
+        externalId: String?
+    ): Either<ApiError, String> = Either.Right(sendToRouteResponse)
 
     companion object {
         val validGetInfoResponse =
@@ -361,6 +375,11 @@ class DummyEclairClient(
         val validPayInvoiceResponse = "e4227601-38b3-404e-9aa0-75a829e9bec0"
 
         val validSendToNodeResponse = "e4227601-38b3-404e-9aa0-75a829e9bec0"
+
+        val validSendToRouteResponse = """{
+  "paymentId": "15798966-5e95-4dce-84a0-825bd2f2a8d1",
+  "parentId": "20b2a854-261a-4e9f-a4ca-59b381aee4bc"
+}"""
     }
 }
 
@@ -455,5 +474,18 @@ class FailingEclairClient(private val error: ApiError) : IEclairClient, IEclairC
         maxFeePct: Int?,
         externalId: String?,
         pathFindingExperimentName: String?
+    ): Either<ApiError, String> = Either.Left(error)
+
+    override suspend fun sendtoroute(
+        invoice: String,
+        nodeIds: List<String>?,
+        shortChannelIds: List<String>?,
+        amountMsat: Int,
+        paymentHash: String,
+        finalCltvExpiry: Int,
+        maxFeeMsat: Int?,
+        recipientAmountMsat: Int?,
+        parentId: String?,
+        externalId: String?
     ): Either<ApiError, String> = Either.Left(error)
 }

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -23,6 +23,7 @@ class DummyEclairClient(
     private val allUpdatesResponse: String = validAllUpdatesResponse,
     private val createInvoiceResponse: String = validCreateInvoiceResponse,
     private val deleteInvoiceResponse: String = validDeleteInvoiceResponse,
+    private val parseInvoiceResponse: String = validParseInvoiceResponse,
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
@@ -92,6 +93,8 @@ class DummyEclairClient(
     ): Either<ApiError, String> = Either.Right(createInvoiceResponse)
 
     override suspend fun deleteinvoice(paymentHash: String): Either<ApiError, String> = Either.Right(deleteInvoiceResponse)
+
+    override suspend fun parseinvoice(invoice: String): Either<ApiError, String> = Either.Right(parseInvoiceResponse)
 
     companion object {
         val validGetInfoResponse =
@@ -310,6 +313,28 @@ class DummyEclairClient(
   "routingInfo": []
 }"""
         val validDeleteInvoiceResponse = "deleted invoice 6f0864735283ca95eaf9c50ef77893f55ee3dd11cb90710cbbfb73f018798a68"
+        val validParseInvoiceResponse = """{
+  "prefix": "lnbcrt",
+  "timestamp": 1643718891,
+  "nodeId": "028e2403fbfddb3d787843361f91adbda64c6f622921b19fb48f5766508bcadb29",
+  "serialized": "lnbcrt500n1pslj28tpp55kxmmddatrnmf42a55mk4wzz4ryq8tv2vwrrarj27e0hhjgpscjqdq0ydex2cmtd3jhxucsp5qu6jq5heq4lcjpj2r8gp0sd65860yzc5yw3xrwde6c4m3mlessxsmqz9gxqrrsscqp79qtzsqqqqqysgqr2fy2yz4655hwql2nwkk3t9saxhj80340cxfzf7fwhweasncv77ym7wcv0p54e4kt7jpmfdavnj5urq84syh9t2t49qdgj4ra8jl40gp6ys45n",
+  "description": "#reckless",
+  "paymentHash": "a58dbdb5bd58e7b4d55da5376ab842a8c803ad8a63863e8e4af65f7bc9018624",
+  "paymentMetadata": "2a",
+  "expiry": 3600,
+  "minFinalCltvExpiry": 30,
+  "amount": 50000,
+  "features": {
+    "activated": {
+      "payment_secret": "mandatory",
+      "basic_mpp": "optional",
+      "option_payment_metadata": "optional",
+      "var_onion_optin": "mandatory"
+    },
+    "unknown": []
+  },
+  "routingInfo": []
+}"""
     }
 }
 
@@ -382,4 +407,6 @@ class FailingEclairClient(private val error: ApiError) : IEclairClient, IEclairC
     ): Either<ApiError, String>  = Either.Left(error)
 
     override suspend fun deleteinvoice(paymentHash: String): Either<ApiError, String> = Either.Left(error)
+
+    override suspend fun parseinvoice(invoice: String): Either<ApiError, String> = Either.Left(error)
 }

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -25,6 +25,7 @@ class DummyEclairClient(
     private val deleteInvoiceResponse: String = validDeleteInvoiceResponse,
     private val parseInvoiceResponse: String = validParseInvoiceResponse,
     private val payInvoiceResponse: String = validPayInvoiceResponse,
+    private val sendToNodeResponse: String = validSendToNodeResponse,
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
@@ -107,6 +108,16 @@ class DummyEclairClient(
         pathFindingExperimentName: String?,
         blocking: Boolean?
     ): Either<ApiError, String> = Either.Right(payInvoiceResponse)
+
+    override suspend fun sendtonode(
+        nodeId: String,
+        amountMsat: Int,
+        maxAttempts: Int?,
+        maxFeeFlatSat: Int?,
+        maxFeePct: Int?,
+        externalId: String?,
+        pathFindingExperimentName: String?
+    ): Either<ApiError, String> = Either.Right(sendToNodeResponse)
 
     companion object {
         val validGetInfoResponse =
@@ -348,6 +359,8 @@ class DummyEclairClient(
   "routingInfo": []
 }"""
         val validPayInvoiceResponse = "e4227601-38b3-404e-9aa0-75a829e9bec0"
+
+        val validSendToNodeResponse = "e4227601-38b3-404e-9aa0-75a829e9bec0"
     }
 }
 
@@ -432,5 +445,15 @@ class FailingEclairClient(private val error: ApiError) : IEclairClient, IEclairC
         externalId: String?,
         pathFindingExperimentName: String?,
         blocking: Boolean?
+    ): Either<ApiError, String> = Either.Left(error)
+
+    override suspend fun sendtonode(
+        nodeId: String,
+        amountMsat: Int,
+        maxAttempts: Int?,
+        maxFeeFlatSat: Int?,
+        maxFeePct: Int?,
+        externalId: String?,
+        pathFindingExperimentName: String?
     ): Either<ApiError, String> = Either.Left(error)
 }

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -21,6 +21,7 @@ class DummyEclairClient(
     private val nodeResponse: String = validNodeResponse,
     private val allChannelsResponse: String = validAllChannelsResponse,
     private val allUpdatesResponse: String = validAllUpdatesResponse,
+    private val createInvoiceResponse: String = validCreateInvoiceResponse,
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
@@ -79,6 +80,15 @@ class DummyEclairClient(
     override suspend fun allchannels(): Either<ApiError, String> = Either.Right(allChannelsResponse)
 
     override suspend fun allupdates(nodeId: String?): Either<ApiError, String> = Either.Right(allUpdatesResponse)
+
+    override suspend fun createinvoice(
+        description: String?,
+        descriptionHash: String?,
+        amountMsat: Int?,
+        expireIn: Int?,
+        fallbackAddress: String?,
+        paymentPreimage: String?
+    ): Either<ApiError, String> = Either.Right(createInvoiceResponse)
 
     companion object {
         val validGetInfoResponse =
@@ -274,6 +284,28 @@ class DummyEclairClient(
     "tlvStream": {}
   }
 ]"""
+        val validCreateInvoiceResponse = """{
+  "prefix": "lnbcrt",
+  "timestamp": 1643718891,
+  "nodeId": "028e2403fbfddb3d787843361f91adbda64c6f622921b19fb48f5766508bcadb29",
+  "serialized": "lnbcrt500n1pslj28tpp55kxmmddatrnmf42a55mk4wzz4ryq8tv2vwrrarj27e0hhjgpscjqdq0ydex2cmtd3jhxucsp5qu6jq5heq4lcjpj2r8gp0sd65860yzc5yw3xrwde6c4m3mlessxsmqz9gxqrrsscqp79qtzsqqqqqysgqr2fy2yz4655hwql2nwkk3t9saxhj80340cxfzf7fwhweasncv77ym7wcv0p54e4kt7jpmfdavnj5urq84syh9t2t49qdgj4ra8jl40gp6ys45n",
+  "description": "#reckless",
+  "paymentHash": "a58dbdb5bd58e7b4d55da5376ab842a8c803ad8a63863e8e4af65f7bc9018624",
+  "paymentMetadata": "2a",
+  "expiry": 3600,
+  "minFinalCltvExpiry": 30,
+  "amount": 50000,
+  "features": {
+    "activated": {
+      "payment_secret": "mandatory",
+      "basic_mpp": "optional",
+      "option_payment_metadata": "optional",
+      "var_onion_optin": "mandatory"
+    },
+    "unknown": []
+  },
+  "routingInfo": []
+}"""
     }
 }
 
@@ -335,4 +367,13 @@ class FailingEclairClient(private val error: ApiError) : IEclairClient, IEclairC
     override suspend fun allchannels(): Either<ApiError, String> = Either.Left(error)
 
     override suspend fun allupdates(nodeId: String?): Either<ApiError, String> = Either.Left(error)
+
+    override suspend fun createinvoice(
+        description: String?,
+        descriptionHash: String?,
+        amountMsat: Int?,
+        expireIn: Int?,
+        fallbackAddress: String?,
+        paymentPreimage: String?
+    ): Either<ApiError, String>  = Either.Left(error)
 }

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -22,6 +22,7 @@ class DummyEclairClient(
     private val allChannelsResponse: String = validAllChannelsResponse,
     private val allUpdatesResponse: String = validAllUpdatesResponse,
     private val createInvoiceResponse: String = validCreateInvoiceResponse,
+    private val deleteInvoiceResponse: String = validDeleteInvoiceResponse,
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
@@ -89,6 +90,8 @@ class DummyEclairClient(
         fallbackAddress: String?,
         paymentPreimage: String?
     ): Either<ApiError, String> = Either.Right(createInvoiceResponse)
+
+    override suspend fun deleteinvoice(paymentHash: String): Either<ApiError, String> = Either.Right(deleteInvoiceResponse)
 
     companion object {
         val validGetInfoResponse =
@@ -306,6 +309,7 @@ class DummyEclairClient(
   },
   "routingInfo": []
 }"""
+        val validDeleteInvoiceResponse = "deleted invoice 6f0864735283ca95eaf9c50ef77893f55ee3dd11cb90710cbbfb73f018798a68"
     }
 }
 
@@ -376,4 +380,6 @@ class FailingEclairClient(private val error: ApiError) : IEclairClient, IEclairC
         fallbackAddress: String?,
         paymentPreimage: String?
     ): Either<ApiError, String>  = Either.Left(error)
+
+    override suspend fun deleteinvoice(paymentHash: String): Either<ApiError, String> = Either.Left(error)
 }

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -27,6 +27,12 @@ class DummyEclairClient(
     private val payInvoiceResponse: String = validPayInvoiceResponse,
     private val sendToNodeResponse: String = validSendToNodeResponse,
     private val sendToRouteResponse: String = validSendToRouteResponse,
+    private val getsentinfoResponse: String = validGetSentInfoResponse,
+    private val getreceivedinfoResponse: String = validGetReceivedInfoResponse,
+    private val listreceivedpaymentsResponse: String = validListReceivedPaymentsResponse,
+    private val getinvoiceResponse: String = validGetInvoiceResponse,
+    private val listinvoicesResponse: String = validListInvoicesResponse,
+    private val listpendinginvoicesResponse: String = validListPendingInvoicesResponse
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
@@ -132,6 +138,36 @@ class DummyEclairClient(
         parentId: String?,
         externalId: String?
     ): Either<ApiError, String> = Either.Right(sendToRouteResponse)
+
+    override suspend fun getsentinfo(
+        paymentHash: String, id: String?
+    ): Either<ApiError, String> = Either.Right(getsentinfoResponse)
+
+    override suspend fun getreceivedinfo(
+        paymentHash: String?, invoice: String?
+    ): Either<ApiError, String> = Either.Right(getreceivedinfoResponse)
+
+    override suspend fun listreceivedpayments(
+        from: Int?, to: Int?, count: Int?, skip: Int?
+    ): Either<ApiError, String> = Either.Right(listreceivedpaymentsResponse)
+
+    override suspend fun getinvoice(
+        paymentHash: String
+    ): Either<ApiError, String> = Either.Right(getinvoiceResponse)
+
+    override suspend fun listinvoices(
+        from: Int?,
+        to: Int?,
+        count: Int?,
+        skip: Int?
+    ): Either<ApiError, String> = Either.Right(listinvoicesResponse)
+
+    override suspend fun listpendinginvoices(
+        from: Int?,
+        to: Int?,
+        count: Int?,
+        skip: Int?
+    ): Either<ApiError, String> = Either.Right(listpendinginvoicesResponse)
 
     companion object {
         val validGetInfoResponse =
@@ -373,13 +409,353 @@ class DummyEclairClient(
   "routingInfo": []
 }"""
         val validPayInvoiceResponse = "e4227601-38b3-404e-9aa0-75a829e9bec0"
-
         val validSendToNodeResponse = "e4227601-38b3-404e-9aa0-75a829e9bec0"
-
         val validSendToRouteResponse = """{
   "paymentId": "15798966-5e95-4dce-84a0-825bd2f2a8d1",
   "parentId": "20b2a854-261a-4e9f-a4ca-59b381aee4bc"
 }"""
+        val validGetSentInfoResponse = """[
+  {
+    "id": "c7b83ae7-a8a2-4ac7-9d54-f13826eaaf06",
+    "parentId": "e0b98732-4ba5-4992-b1c3-5efb4084bcd3",
+    "paymentHash": "e170db22f72678848b90d4d10095e6863c79a39717ccdcfab18106248b93305c",
+    "paymentType": "Standard",
+    "amount": 2000000,
+    "recipientAmount": 5000000,
+    "recipientNodeId": "02fe677ac8cd61399d097535a3e8a51a0849e57cdbab9b34796c86f3e33568cbe2",
+    "createdAt": {
+      "iso": "2022-02-01T12:40:19.309Z",
+      "unix": 1643719219
+    },
+    "invoice": {
+      "prefix": "lnbcrt",
+      "timestamp": 1643719211,
+      "nodeId": "02fe677ac8cd61399d097535a3e8a51a0849e57cdbab9b34796c86f3e33568cbe2",
+      "serialized": "lnbcrt50u1pslj23tpp5u9cdkghhyeugfzus6ngsp90xsc78nguhzlxde743syrzfzunxpwqdq809hkcmcsp5tp7xegstgfpyjyg2cqclsthwr330g9g3p0dmn0g6v9t6dn6n9s4smqz9gxqrrsscqp79qtzsqqqqqysgq20s4qnk7xq0dcwjustztkx4ez0mqlmg83s5y6gk4u7ug6qk3cwuxq9ehqn4kyp580gqwp4nxwh598j40pqnlals2m0pem7f0qz0xm8qqe25z82",
+      "description": "#reckless",
+      "paymentHash": "e170db22f72678848b90d4d10095e6863c79a39717ccdcfab18106248b93305c",
+      "paymentMetadata": "2a",
+      "expiry": 3600,
+      "minFinalCltvExpiry": 30,
+      "amount": 5000000,
+      "features": {
+        "activated": {
+          "payment_secret": "mandatory",
+          "basic_mpp": "optional",
+          "option_payment_metadata": "optional",
+          "var_onion_optin": "mandatory"
+        },
+        "unknown": []
+      },
+      "routingInfo": []
+    },
+    "status": {
+      "type": "sent",
+      "paymentPreimage": "533b360e08d0d7383d0125e3510eaf5d7e36e21b847446cf64a84973800bc48c",
+      "feesPaid": 10,
+      "route": [
+        {
+          "nodeId": "03dfefbc942ac877655af00c4a6e9314626438e4aaba141412d825d5f2304bf0bf",
+          "nextNodeId": "02f5ce007d2d9ef8a72a03b8e33f63fe9384cea4e71c1de468737611ce3e68ac02",
+          "shortChannelId": "538x3x0"
+        },
+        {
+          "nodeId": "02f5ce007d2d9ef8a72a03b8e33f63fe9384cea4e71c1de468737611ce3e68ac02",
+          "nextNodeId": "02d150875194d076f662d4252a8dee7077ed4cc4a848bb9f83fb467b6d3c120199",
+          "shortChannelId": "538x2x1"
+        }
+      ],
+      "completedAt": {
+        "iso": "2022-02-01T12:40:19.438Z",
+        "unix": 1643719219
+      }
+    }
+  },
+  {
+    "id": "83fcc569-917a-4cac-b42d-6f6b186f21eb",
+    "parentId": "e0b98732-4ba5-4992-b1c3-5efb4084bcd3",
+    "paymentHash": "e170db22f72678848b90d4d10095e6863c79a39717ccdcfab18106248b93305c",
+    "paymentType": "Standard",
+    "amount": 3000000,
+    "recipientAmount": 5000000,
+    "recipientNodeId": "02fe677ac8cd61399d097535a3e8a51a0849e57cdbab9b34796c86f3e33568cbe2",
+    "createdAt": {
+      "iso": "2022-02-01T12:40:19.309Z",
+      "unix": 1643719219
+    },
+    "invoice": {
+      "prefix": "lnbcrt",
+      "timestamp": 1643719211,
+      "nodeId": "02fe677ac8cd61399d097535a3e8a51a0849e57cdbab9b34796c86f3e33568cbe2",
+      "serialized": "lnbcrt50u1pslj23tpp5u9cdkghhyeugfzus6ngsp90xsc78nguhzlxde743syrzfzunxpwqdq809hkcmcsp5tp7xegstgfpyjyg2cqclsthwr330g9g3p0dmn0g6v9t6dn6n9s4smqz9gxqrrsscqp79qtzsqqqqqysgq20s4qnk7xq0dcwjustztkx4ez0mqlmg83s5y6gk4u7ug6qk3cwuxq9ehqn4kyp580gqwp4nxwh598j40pqnlals2m0pem7f0qz0xm8qqe25z82",
+      "description": "#reckless",
+      "paymentHash": "e170db22f72678848b90d4d10095e6863c79a39717ccdcfab18106248b93305c",
+      "paymentMetadata": "2a",
+      "expiry": 3600,
+      "minFinalCltvExpiry": 30,
+      "amount": 5000000,
+      "features": {
+        "activated": {
+          "payment_secret": "mandatory",
+          "basic_mpp": "optional",
+          "option_payment_metadata": "optional",
+          "var_onion_optin": "mandatory"
+        },
+        "unknown": []
+      },
+      "routingInfo": []
+    },
+    "status": {
+      "type": "sent",
+      "paymentPreimage": "533b360e08d0d7383d0125e3510eaf5d7e36e21b847446cf64a84973800bc48c",
+      "feesPaid": 15,
+      "route": [
+        {
+          "nodeId": "03dfefbc942ac877655af00c4a6e9314626438e4aaba141412d825d5f2304bf0bf",
+          "nextNodeId": "02f5ce007d2d9ef8a72a03b8e33f63fe9384cea4e71c1de468737611ce3e68ac02",
+          "shortChannelId": "538x4x1"
+        },
+        {
+          "nodeId": "02f5ce007d2d9ef8a72a03b8e33f63fe9384cea4e71c1de468737611ce3e68ac02",
+          "nextNodeId": "02d150875194d076f662d4252a8dee7077ed4cc4a848bb9f83fb467b6d3c120199",
+          "shortChannelId": "538x2x1"
+        }
+      ],
+      "completedAt": {
+        "iso": "2022-02-01T12:40:19.438Z",
+        "unix": 1643719219
+      }
+    }
+  }
+]"""
+        val validGetReceivedInfoResponse = """{
+  "invoice": {
+    "prefix": "lnbcrt",
+    "timestamp": 1643719211,
+    "nodeId": "02fe677ac8cd61399d097535a3e8a51a0849e57cdbab9b34796c86f3e33568cbe2",
+    "serialized": "lnbcrt50u1pslj23tpp5u9cdkghhyeugfzus6ngsp90xsc78nguhzlxde743syrzfzunxpwqdq809hkcmcsp5tp7xegstgfpyjyg2cqclsthwr330g9g3p0dmn0g6v9t6dn6n9s4smqz9gxqrrsscqp79qtzsqqqqqysgq20s4qnk7xq0dcwjustztkx4ez0mqlmg83s5y6gk4u7ug6qk3cwuxq9ehqn4kyp580gqwp4nxwh598j40pqnlals2m0pem7f0qz0xm8qqe25z82",
+    "description": "#reckless",
+    "paymentHash": "e170db22f72678848b90d4d10095e6863c79a39717ccdcfab18106248b93305c",
+    "paymentMetadata": "2a",
+    "expiry": 3600,
+    "minFinalCltvExpiry": 30,
+    "amount": 5000000,
+    "features": {
+      "activated": {
+        "payment_secret": "mandatory",
+        "basic_mpp": "optional",
+        "option_payment_metadata": "optional",
+        "var_onion_optin": "mandatory"
+      },
+      "unknown": []
+    },
+    "routingInfo": []
+  },
+  "paymentPreimage": "533b360e08d0d7383d0125e3510eaf5d7e36e21b847446cf64a84973800bc48c",
+  "paymentType": "Standard",
+  "createdAt": {
+    "iso": "2022-02-01T12:40:11Z",
+    "unix": 1643719211
+  },
+  "status": {
+    "type": "received",
+    "amount": 5000000,
+    "receivedAt": {
+      "iso": "2022-02-01T12:40:19.423Z",
+      "unix": 1643719219
+    }
+  }
+}"""
+        val validListReceivedPaymentsResponse = """[
+  {
+    "invoice": {
+      "prefix": "lnbcrt",
+      "timestamp": 1686839336,
+      "nodeId": "02ca41676c9dfff08553528b151b1bf82031a26bb1d6f852e0f8075d33fa4ea089",
+      "serialized": "lnbcrt500u1pjgkgpgpp5qw2c953gwadm9zevstlq04ffl870tzmjdvg7c03x840xtcdkavgsdq809hkcmcsp5rvgyuy7hmtuc5ljmr645yfntrrwgyumnsp43w60xdrw9gnjprauqmqz9gxqrrsscqp79q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgq7pwcsn9nfrvf46nkmctqnwuj3rvt7erx4494k4sa8uawajyz39sx8jd8t8l3kq4z3w653xu9uqvsjekyu478egx7ftwwzl2m8n7nqagqm7nqs9",
+      "description": "yolo",
+      "paymentHash": "039582d228775bb28b2c82fe07d529f9fcf58b726b11ec3e263d5e65e1b6eb11",
+      "paymentMetadata": "2a",
+      "expiry": 3600,
+      "minFinalCltvExpiry": 30,
+      "amount": 50000000,
+      "features": {
+        "activated": {
+          "trampoline_payment_prototype": "optional",
+          "payment_secret": "mandatory",
+          "basic_mpp": "optional",
+          "option_payment_metadata": "optional",
+          "var_onion_optin": "mandatory"
+        },
+        "unknown": []
+      },
+      "routingInfo": []
+    },
+    "paymentPreimage": "f3fcdefcd38481666f624ba68ca17ad620ca8c98bbec5f0616ba11ff11d6096e",
+    "paymentType": "Standard",
+    "createdAt": {
+      "iso": "2023-06-15T14:28:56Z",
+      "unix": 1686839336
+    },
+    "status": {
+      "type": "received",
+      "amount": 50000000,
+      "receivedAt": {
+        "iso": "2023-06-15T14:30:32.564Z",
+        "unix": 1686839432
+      }
+    }
+  },
+  {
+    "invoice": {
+      "prefix": "lnbcrt",
+      "timestamp": 1686839569,
+      "nodeId": "02ca41676c9dfff08553528b151b1bf82031a26bb1d6f852e0f8075d33fa4ea089",
+      "serialized": "lnbcrt100u1pjgkgg3pp529amjg068drrefp02mxz8907gdnea3jqn6fss7y4zw07uswr2w6sdq809hkcmcsp5njg0whsxvzuqtp5wpzsma0jhphch7r9z45yzjjpg500dpcdqw3csmqz9gxqrrsscqp79q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgq629ldsmfufcerxkc562mh7dz5sr5x68zyhpxhg0qv6qfvhvv7w6yw0gtxqlyu4fw8kzrcd5etu24gy34dv276m3wmf8jfa069m3c4tqqx4dxns",
+      "description": "yolo",
+      "paymentHash": "517bb921fa3b463ca42f56cc2395fe43679ec6409e93087895139fee41c353b5",
+      "paymentMetadata": "2a",
+      "expiry": 3600,
+      "minFinalCltvExpiry": 30,
+      "amount": 10000000,
+      "features": {
+        "activated": {
+          "trampoline_payment_prototype": "optional",
+          "payment_secret": "mandatory",
+          "basic_mpp": "optional",
+          "option_payment_metadata": "optional",
+          "var_onion_optin": "mandatory"
+        },
+        "unknown": []
+      },
+      "routingInfo": []
+    },
+    "paymentPreimage": "8c13992095e5ad50ed6675b5f5e87e786fed3cd39209f8ced2e67fadf6567c7b",
+    "paymentType": "Standard",
+    "createdAt": {
+      "iso": "2023-06-15T14:32:49Z",
+      "unix": 1686839569
+    },
+    "status": {
+      "type": "received",
+      "amount": 10000000,
+      "receivedAt": {
+        "iso": "2023-06-15T14:32:57.631Z",
+        "unix": 1686839577
+      }
+    }
+  }
+]"""
+        val validGetInvoiceResponse = """{
+  "prefix": "lnbcrt",
+  "timestamp": 1643718891,
+  "nodeId": "028e2403fbfddb3d787843361f91adbda64c6f622921b19fb48f5766508bcadb29",
+  "serialized": "lnbcrt500n1pslj28tpp55kxmmddatrnmf42a55mk4wzz4ryq8tv2vwrrarj27e0hhjgpscjqdq0ydex2cmtd3jhxucsp5qu6jq5heq4lcjpj2r8gp0sd65860yzc5yw3xrwde6c4m3mlessxsmqz9gxqrrsscqp79qtzsqqqqqysgqr2fy2yz4655hwql2nwkk3t9saxhj80340cxfzf7fwhweasncv77ym7wcv0p54e4kt7jpmfdavnj5urq84syh9t2t49qdgj4ra8jl40gp6ys45n",
+  "description": "#reckless",
+  "paymentHash": "a58dbdb5bd58e7b4d55da5376ab842a8c803ad8a63863e8e4af65f7bc9018624",
+  "paymentMetadata": "2a",
+  "expiry": 3600,
+  "minFinalCltvExpiry": 30,
+  "amount": 50000,
+  "features": {
+    "activated": {
+      "payment_secret": "mandatory",
+      "basic_mpp": "optional",
+      "option_payment_metadata": "optional",
+      "var_onion_optin": "mandatory"
+    },
+    "unknown": []
+  },
+  "routingInfo": []
+}"""
+        val validListInvoicesResponse = """[
+  {
+    "prefix": "lnbcrt",
+    "timestamp": 1643719798,
+    "nodeId": "028e2403fbfddb3d787843361f91adbda64c6f622921b19fb48f5766508bcadb29",
+    "serialized": "lnbcrt1psljtrkpp5gqus3ys83p9cry4nj43ykjyvkuuhrcc5y45a6l569zwuc8pn2xxsdq0ydex2cmtd3jhxucsp543t76xycc9kpx4estwm6tjlpsht3m7d5jxe09tqnyjjux970y9lsmqz9gxqrrsscqp79qtzsqqqqqysgqxwh55ncvj3hv0cypm8vafku83gayzg7qa3zlu3lua76lk53t2m3rgt4d5qa04cfdd0f407p328c9el9xvy3r6z9um90m5pjaxrrazysqfkxfa7",
+    "description": "#reckless",
+    "paymentHash": "4039089207884b8192b395624b488cb73971e3142569dd7e9a289dcc1c33518d",
+    "paymentMetadata": "2a",
+    "expiry": 3600,
+    "minFinalCltvExpiry": 30,
+    "features": {
+      "activated": {
+        "payment_secret": "mandatory",
+        "basic_mpp": "optional",
+        "option_payment_metadata": "optional",
+        "var_onion_optin": "mandatory"
+      },
+      "unknown": []
+    },
+    "routingInfo": []
+  },
+  {
+    "prefix": "lnbcrt",
+    "timestamp": 1643719828,
+    "nodeId": "028e2403fbfddb3d787843361f91adbda64c6f622921b19fb48f5766508bcadb29",
+    "serialized": "lnbcrt1psljty5pp5z2247c5w8cl30err7s9qx8rkejltq49mk8z6l5eqar7l43pehapsdq0ydex2cmtd3jhxucsp5hrcu5s0jftrmje4yavu580tlrq4mdmdevye8aevn6dsae4x5kejqmqz9gxqrrsscqp79qtzsqqqqqysgqwus3au5085tp02cwvpjexc5rq6qjezwxwr3yecdxr525qprv5zjxa98r69kx87cegavjw9u9299yfdhnes7mp4dztttyduchudvq64cq4pyx28",
+    "description": "#reckless",
+    "paymentHash": "12955f628e3e3f17e463f40a031c76ccbeb054bbb1c5afd320e8fdfac439bf43",
+    "paymentMetadata": "2a",
+    "expiry": 3600,
+    "minFinalCltvExpiry": 30,
+    "features": {
+      "activated": {
+        "payment_secret": "mandatory",
+        "basic_mpp": "optional",
+        "option_payment_metadata": "optional",
+        "var_onion_optin": "mandatory"
+      },
+      "unknown": []
+    },
+    "routingInfo": []
+  }
+]"""
+        val validListPendingInvoicesResponse = """[
+  {
+    "prefix": "lnbcrt",
+    "timestamp": 1643719798,
+    "nodeId": "028e2403fbfddb3d787843361f91adbda64c6f622921b19fb48f5766508bcadb29",
+    "serialized": "lnbcrt1psljtrkpp5gqus3ys83p9cry4nj43ykjyvkuuhrcc5y45a6l569zwuc8pn2xxsdq0ydex2cmtd3jhxucsp543t76xycc9kpx4estwm6tjlpsht3m7d5jxe09tqnyjjux970y9lsmqz9gxqrrsscqp79qtzsqqqqqysgqxwh55ncvj3hv0cypm8vafku83gayzg7qa3zlu3lua76lk53t2m3rgt4d5qa04cfdd0f407p328c9el9xvy3r6z9um90m5pjaxrrazysqfkxfa7",
+    "description": "#reckless",
+    "paymentHash": "4039089207884b8192b395624b488cb73971e3142569dd7e9a289dcc1c33518d",
+    "paymentMetadata": "2a",
+    "expiry": 3600,
+    "minFinalCltvExpiry": 30,
+    "features": {
+      "activated": {
+        "payment_secret": "mandatory",
+        "basic_mpp": "optional",
+        "option_payment_metadata": "optional",
+        "var_onion_optin": "mandatory"
+      },
+      "unknown": []
+    },
+    "routingInfo": []
+  },
+  {
+    "prefix": "lnbcrt",
+    "timestamp": 1643719828,
+    "nodeId": "028e2403fbfddb3d787843361f91adbda64c6f622921b19fb48f5766508bcadb29",
+    "serialized": "lnbcrt1psljty5pp5z2247c5w8cl30err7s9qx8rkejltq49mk8z6l5eqar7l43pehapsdq0ydex2cmtd3jhxucsp5hrcu5s0jftrmje4yavu580tlrq4mdmdevye8aevn6dsae4x5kejqmqz9gxqrrsscqp79qtzsqqqqqysgqwus3au5085tp02cwvpjexc5rq6qjezwxwr3yecdxr525qprv5zjxa98r69kx87cegavjw9u9299yfdhnes7mp4dztttyduchudvq64cq4pyx28",
+    "description": "#reckless",
+    "paymentHash": "12955f628e3e3f17e463f40a031c76ccbeb054bbb1c5afd320e8fdfac439bf43",
+    "paymentMetadata": "2a",
+    "expiry": 3600,
+    "minFinalCltvExpiry": 30,
+    "features": {
+      "activated": {
+        "payment_secret": "mandatory",
+        "basic_mpp": "optional",
+        "option_payment_metadata": "optional",
+        "var_onion_optin": "mandatory"
+      },
+      "unknown": []
+    },
+    "routingInfo": []
+  }
+]"""
     }
 }
 
@@ -488,4 +864,16 @@ class FailingEclairClient(private val error: ApiError) : IEclairClient, IEclairC
         parentId: String?,
         externalId: String?
     ): Either<ApiError, String> = Either.Left(error)
+
+    override suspend fun getsentinfo(paymentHash: String, id: String?): Either<ApiError, String> =  Either.Left(error)
+
+    override suspend fun getreceivedinfo(paymentHash: String?, invoice: String?): Either<ApiError, String> =  Either.Left(error)
+
+    override suspend fun listreceivedpayments(from: Int?, to: Int?, count: Int?, skip: Int?): Either<ApiError, String> = Either.Left(error)
+
+    override suspend fun getinvoice(paymentHash: String): Either<ApiError, String> = Either.Left(error)
+
+    override suspend fun listinvoices(from: Int?, to: Int?, count: Int?, skip: Int?): Either<ApiError, String> = Either.Left(error)
+
+    override suspend fun listpendinginvoices(from: Int?, to: Int?, count: Int?, skip: Int?): Either<ApiError, String> = Either.Left(error)
 }

--- a/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
+++ b/src/nativeTest/kotlin/mocks/EclairClientMocks.kt
@@ -24,6 +24,7 @@ class DummyEclairClient(
     private val createInvoiceResponse: String = validCreateInvoiceResponse,
     private val deleteInvoiceResponse: String = validDeleteInvoiceResponse,
     private val parseInvoiceResponse: String = validParseInvoiceResponse,
+    private val payInvoiceResponse: String = validPayInvoiceResponse,
 ) : IEclairClient, IEclairClientBuilder {
     override fun build(apiHost: String, apiPassword: String): IEclairClient = this
     override suspend fun getInfo(): Either<ApiError, String> = Either.Right(getInfoResponse)
@@ -95,6 +96,17 @@ class DummyEclairClient(
     override suspend fun deleteinvoice(paymentHash: String): Either<ApiError, String> = Either.Right(deleteInvoiceResponse)
 
     override suspend fun parseinvoice(invoice: String): Either<ApiError, String> = Either.Right(parseInvoiceResponse)
+
+    override suspend fun payinvoice(
+        invoice: String,
+        amountMsat: Int?,
+        maxAttempts: Int?,
+        maxFeeFlatSat: Int?,
+        maxFeePct: Int?,
+        externalId: String?,
+        pathFindingExperimentName: String?,
+        blocking: Boolean?
+    ): Either<ApiError, String> = Either.Right(payInvoiceResponse)
 
     companion object {
         val validGetInfoResponse =
@@ -335,6 +347,7 @@ class DummyEclairClient(
   },
   "routingInfo": []
 }"""
+        val validPayInvoiceResponse = "e4227601-38b3-404e-9aa0-75a829e9bec0"
     }
 }
 
@@ -404,9 +417,20 @@ class FailingEclairClient(private val error: ApiError) : IEclairClient, IEclairC
         expireIn: Int?,
         fallbackAddress: String?,
         paymentPreimage: String?
-    ): Either<ApiError, String>  = Either.Left(error)
+    ): Either<ApiError, String> = Either.Left(error)
 
     override suspend fun deleteinvoice(paymentHash: String): Either<ApiError, String> = Either.Left(error)
 
     override suspend fun parseinvoice(invoice: String): Either<ApiError, String> = Either.Left(error)
+
+    override suspend fun payinvoice(
+        invoice: String,
+        amountMsat: Int?,
+        maxAttempts: Int?,
+        maxFeeFlatSat: Int?,
+        maxFeePct: Int?,
+        externalId: String?,
+        pathFindingExperimentName: String?,
+        blocking: Boolean?
+    ): Either<ApiError, String> = Either.Left(error)
 }


### PR DESCRIPTION
The commands implemented are:

- [x] CreateInvoice
- [x] DeleteInvoice
- [x] ParseInvoice
- [x] PayInvoice
- [x] SendToNode
- [x] SendToRoute
- [x] GetSentInfo
- [x] GetRecievedInfo
- [x] ListReceivedPayments
- [x] GetInvoice
- [x] ListInvoice
- [x] ListPendingInvoices